### PR TITLE
Update profiles map to match real CSV headers

### DIFF
--- a/cfg/profiles_map.yml
+++ b/cfg/profiles_map.yml
@@ -1,4 +1,4 @@
-﻿version: 1
+version: 1
 defaults:
   delimiter: ";"
   decimal: ","
@@ -12,43 +12,77 @@ profiles:
     source: SUCESSOR
     detect:
       required_any:
-        - "(?i)data"
-        - "(?i)debito"
-        - "(?i)credito"
-        - "(?i)doc"
+        - '(?i)^data'
+        - '(?i)d.?bito'
+        - '(?i)c.?r.?dito'
+        - '(?i)doct?o|documento'
     csv:
       delimiter: ";"
       decimal: ","
     map:
-      data: ["(?i)^data"]
-      debito: ["(?i)debito"]
-      credito: ["(?i)credito"]
-      part_d: ["(?i)part.*deb"]
-      part_c: ["(?i)part.*cred"]
-      doc: ["(?i)doc"]
-      valor: ["(?i)valor"]
-      historico: ["(?i)hist"]
-      transacao_id: ["(?i)trans"]
+      data:
+        - '(?i)^data'
+        - '(?i)data\s*(?:lanc|emis)'
+      debito:
+        - '(?i)conta\s*d.?bito'
+        - '(?i)^d.?bito$'
+      credito:
+        - '(?i)conta\s*c.?r.?dito'
+        - '(?i)^c.?r.?dito$'
+      part_d:
+        - '(?i)participante\s*d'
+        - '(?i)part.*deb'
+      part_c:
+        - '(?i)participante\s*c'
+        - '(?i)part.*cred'
+      doc:
+        - '(?i)n.?\s*doct?o'
+        - '(?i)nr?.?\s*doc'
+        - '(?i)documento'
+      valor:
+        - '(?i)^valor'
+      historico:
+        - '(?i)^hist'
+      transacao_id:
+        - '(?i)^transa'
+        - '(?i)transacao'
 
   - id: suprema_entradas_v1
     source: SUPREMA_ENTRADA
     detect:
       required_any:
-        - "(?i)fornecedor"
-        - "(?i)cfop"
-        - "(?i)valor"
+        - '(?i)fornecedor'
+        - '(?i)cfop'
+        - '(?i)valor'
     map:
-      data: ["(?i)data"]
-      doc: ["(?i)doc"]
-      participante: ["(?i)fornecedor|participante"]
-      valor: ["(?i)valor"]
-      cfop: ["(?i)cfop"]
-      modelo: ["(?i)modelo"]
-      situacao: ["(?i)situacao"]
-      debito_alias: ["(?i)debito"]
-      credito_alias: ["(?i)credito"]
-      condicao: ["(?i)condicao"]
-      chave_xml: ["(?i)chave"]
+      data:
+        - '(?i)data\s*emis'
+        - '(?i)data'
+      doc:
+        - '(?i)^doc'
+        - '(?i)nr?.?\s*doc'
+        - '(?i)documento'
+      participante:
+        - '(?i)^nome\s*fornecedor$'
+        - '(?i)fornecedor'
+      valor:
+        - '(?i)valor'
+      cfop:
+        - '(?i)cfop'
+      modelo:
+        - '(?i)modelo'
+      situacao:
+        - '(?i)situa'
+      debito_alias:
+        - '(?i)^d.?bito$'
+        - '(?i)debito'
+      credito_alias:
+        - '(?i)^c.?r.?dito$'
+        - '(?i)credito'
+      condicao:
+        - '(?i)cond[ií]c'
+      chave_xml:
+        - '(?i)^chave'
     fixed:
       fonte_tipo: ENTRADA
 
@@ -56,21 +90,38 @@ profiles:
     source: SUPREMA_SAIDA
     detect:
       required_any:
-        - "(?i)cliente"
-        - "(?i)cfop"
-        - "(?i)valor"
+        - '(?i)cliente'
+        - '(?i)cfop'
+        - '(?i)valor'
     map:
-      data: ["(?i)data"]
-      doc: ["(?i)doc"]
-      participante: ["(?i)cliente|participante"]
-      valor: ["(?i)valor"]
-      cfop: ["(?i)cfop"]
-      modelo: ["(?i)modelo"]
-      situacao: ["(?i)situacao"]
-      debito_alias: ["(?i)debito"]
-      credito_alias: ["(?i)credito"]
-      condicao: ["(?i)condicao"]
-      chave_xml: ["(?i)chave"]
+      data:
+        - '(?i)data\s*emis'
+        - '(?i)data'
+      doc:
+        - '(?i)^doc'
+        - '(?i)nr?.?\s*doc'
+        - '(?i)documento'
+      participante:
+        - '(?i)^nome\s*cliente$'
+        - '(?i)cliente'
+      valor:
+        - '(?i)valor'
+      cfop:
+        - '(?i)cfop'
+      modelo:
+        - '(?i)modelo'
+      situacao:
+        - '(?i)situa'
+      debito_alias:
+        - '(?i)^d.?bito$'
+        - '(?i)debito'
+      credito_alias:
+        - '(?i)^c.?r.?dito$'
+        - '(?i)credito'
+      condicao:
+        - '(?i)cond[ií]c'
+      chave_xml:
+        - '(?i)^chave'
     fixed:
       fonte_tipo: SAIDA
 
@@ -78,17 +129,31 @@ profiles:
     source: SUPREMA_SERVICO
     detect:
       required_any:
-        - "(?i)serv"
-        - "(?i)valor"
+        - '(?i)serv'
+        - '(?i)valor'
     map:
-      data: ["(?i)data"]
-      doc: ["(?i)doc|rps"]
-      participante: ["(?i)tomador|fornecedor|cliente|participante"]
-      valor: ["(?i)valor"]
-      cfop: ["(?i)cfop"]
-      situacao: ["(?i)situacao"]
-      debito_alias: ["(?i)debito"]
-      credito_alias: ["(?i)credito"]
+      data:
+        - '(?i)data\s*emis'
+        - '(?i)data'
+      doc:
+        - '(?i)^doc'
+        - '(?i)nr?.?\s*doc'
+        - '(?i)rps'
+      participante:
+        - '(?i)^cliente$'
+        - '(?i)tomador'
+        - '(?i)fornecedor'
+        - '(?i)participante'
+      valor:
+        - '(?i)valor'
+      cfop:
+        - '(?i)cfop|nat.*oper'
+      situacao:
+        - '(?i)situa'
+      debito_alias:
+        - '(?i)debito'
+      credito_alias:
+        - '(?i)credito'
     fixed:
       fonte_tipo: SERVICO
 
@@ -96,21 +161,33 @@ profiles:
     source: FORNECEDORES
     detect:
       required_any:
-        - "(?i)fornecedor"
-        - "(?i)cnpj"
+        - '(?i)fornecedor'
+        - '(?i)cnpj'
     map:
-      codigo: ["(?i)cod"]
-      nome: ["(?i)nome|razao"]
-      cnpj: ["(?i)cnpj"]
+      codigo:
+        - '(?i)cod'
+      nome:
+        - '(?i)nome'
+        - '(?i)razao'
+      cnpj:
+        - '(?i)cnpj'
 
   - id: plano_contas_v1
     source: PLANO_CONTAS
     detect:
       required_any:
-        - "(?i)plano"
-        - "(?i)conta"
+        - '(?i)plano'
+        - '(?i)conta'
     map:
-      codigo: ["(?i)cod|conta"]
-      alias: ["(?i)alias|apelido|reduzido"]
-      nome: ["(?i)nome|descricao"]
-      natureza: ["(?i)natureza|tipo"]
+      codigo:
+        - '(?i)cod|conta'
+      alias:
+        - '(?i)alias'
+        - '(?i)apelido'
+        - '(?i)reduzido'
+      nome:
+        - '(?i)nome'
+        - '(?i)descricao'
+      natureza:
+        - '(?i)natureza'
+        - '(?i)tipo'


### PR DESCRIPTION
## Summary
- expand the canonical profiles in `cfg/profiles_map.yml` so each regex matches the actual column names present in the supplied CSV exports
- keep detection logic aligned with the new headers while retaining compatibility with the existing fixture data

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3d9b8c7b8832fbf39060b37fa7733