### PR TITLE
Handle None values when sorting API grid

### DIFF
--- a/src/ui_server.py
+++ b/src/ui_server.py
@@ -168,7 +168,10 @@ def api_grid(
 
     if sort_by:
         reverse = sort_dir.lower() != "asc"
-        filtered.sort(key=lambda item: item.get(sort_by), reverse=reverse)
+        filtered.sort(
+            key=lambda item: (item.get(sort_by) is None, item.get(sort_by)),
+            reverse=reverse,
+        )
 
     paginated = filtered[offset : offset + limit]
     return {

--- a/tests/test_ui_server_api.py
+++ b/tests/test_ui_server_api.py
@@ -1,0 +1,47 @@
+import importlib
+import json
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def reload_ui_server(monkeypatch, tmp_path):
+    data_dir = tmp_path / "out"
+    data_dir.mkdir()
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+
+    if "ui_server" in sys.modules:
+        module = importlib.reload(sys.modules["ui_server"])
+    else:
+        module = importlib.import_module("ui_server")
+    yield module, data_dir
+    importlib.reload(module)
+
+
+def test_api_grid_sorts_scores_with_none(reload_ui_server):
+    module, data_dir = reload_ui_server
+    grid_path = data_dir / "ui_grid.jsonl"
+    rows = [
+        {"id": 1, "score": 90},
+        {"id": 2, "score": None},
+        {"id": 3, "score": 75},
+    ]
+    grid_path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    base_kwargs = {
+        "limit": 200,
+        "offset": 0,
+        "status": None,
+        "fonte_tipo": None,
+        "cfop": None,
+        "q": None,
+    }
+
+    ascending = module.api_grid(sort_by="score", sort_dir="asc", **base_kwargs)
+    asc_scores = [item["score"] for item in ascending["items"]]
+    assert asc_scores == [75, 90, None]
+
+    descending = module.api_grid(sort_by="score", sort_dir="desc", **base_kwargs)
+    desc_scores = [item["score"] for item in descending["items"]]
+    assert desc_scores == [None, 90, 75]


### PR DESCRIPTION
## Summary
- ensure the grid sorting logic handles None values by using a composite key that keeps sorting stable
- add an API test that exercises /api/grid sorting when score mixes numeric and None entries

## Testing
- `pytest tests/test_ui_server_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6a3f0d344832f97f58fa14d0ebb06