### PR TITLE
Fix API base comment formatting in UI app

### DIFF
--- a/src/ui_app.html
+++ b/src/ui_app.html
@@ -44,7 +44,8 @@ const DEFAULT_API_BASE = (() => {
   }
   return "http://localhost:8000";
 })();
-// Ajuste `window.UI_API_BASE` ou adicione ?api=http://host:porta na URL antes de carregar o arquivo para definir outro endpoint.
+// Ajuste `window.UI_API_BASE` ou adicione ?api=http://host:porta na URL antes de carregar o arquivo
+// para definir outro endpoint.
 
 const STATUS_COLORS = {
   "OK": {bg:"#d1fae5", badge:"#16a34a", text:"#052e16"},


### PR DESCRIPTION
## Summary
- split the API base override comment into two JavaScript comment lines to remove the stray period expression and restore valid syntax

## Testing
- browser_container.run_playwright_script (reload src/ui_app.html; only fetch errors due to API offline, no `toolbarStats` console error)


------
https://chatgpt.com/codex/tasks/task_e_68d6a972c838832f971c8a4e29eed49f