### PR TITLE
Handle matcher CSV fallbacks

### DIFF
--- a/src/matcher.py
+++ b/src/matcher.py
@@ -273,11 +273,22 @@ class Candidate:
 def load_table_generic(path: Optional[str]) -> pd.DataFrame:
     if not path:
         return pd.DataFrame()
+
     fpath = Path(path)
+    suffix = fpath.suffix.lower()
+
+    if suffix == ".parquet":
+        csv_fallback = fpath.with_suffix(".csv")
+        try:
+            return pd.read_parquet(fpath)
+        except (FileNotFoundError, ImportError, ValueError):
+            if csv_fallback.exists():
+                return pd.read_csv(csv_fallback, dtype=str, keep_default_na=False, encoding="utf-8")
+            return pd.DataFrame()
+
     if not fpath.exists():
         return pd.DataFrame()
-    if fpath.suffix.lower() == ".parquet":
-        return pd.read_parquet(fpath)
+
     return pd.read_csv(fpath, dtype=str, keep_default_na=False, encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary
- add a helper to resolve normalized tables to either Parquet or CSV outputs when building matcher arguments
- update matcher loading to gracefully fall back to CSV files when Parquet support or files are missing
- extend pipeline tests to cover CSV fallback behaviour

## Testing
- pytest tests/test_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68d6d4038724832fb61d4265fd69d1e1