### PR TITLE
Fix decimal rounding in normalizer

### DIFF
--- a/src/normalizer.py
+++ b/src/normalizer.py
@@ -6,11 +6,18 @@ import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
 import pandas as pd
 import yaml
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TWO_CENTS = Decimal("0.01")
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -57,12 +64,13 @@ def parse_decimal(text: Optional[str], decimal: str = ",") -> Optional[float]:
     if not match:
         return None
     try:
-        value = float(match.group(0))
-    except ValueError:
+        value = Decimal(match.group(0))
+    except (ValueError, InvalidOperation):
         return None
     if "(" in raw and ")" in raw:
         value = -abs(value)
-    return value
+    value = value.quantize(TWO_CENTS, rounding=ROUND_HALF_UP)
+    return float(value)
 
 
 def parse_date(text: Optional[str], formats: Iterable[str]) -> Optional[datetime]:


### PR DESCRIPTION
## Summary
- import decimal helpers and define a constant for cent-level rounding
- ensure `parse_decimal` converts to `Decimal` and quantizes before returning

## Testing
- python src/normalizer.py --staging out/staging --out out/normalized --profiles cfg/profiles_map.yml


------
https://chatgpt.com/codex/tasks/task_e_68d6e29a1524832fbd63eb54b736b9bc