### PR TITLE
Serve UI HTML from dedicated endpoint

### DIFF
--- a/src/ui_server.py
+++ b/src/ui_server.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 try:
@@ -86,12 +86,20 @@ def _relative_download(path: Path) -> Optional[str]:
     return f"/files/{rel.as_posix()}"
 
 
-@app.get("/", response_class=HTMLResponse)
-def index() -> HTMLResponse:
+def _ui_app_html() -> str:
     if not UI_APP_PATH.exists():
         raise HTTPException(500, detail=f"ui_app.html not found at {UI_APP_PATH}")
-    html = UI_APP_PATH.read_text(encoding="utf-8")
-    return HTMLResponse(html)
+    return UI_APP_PATH.read_text(encoding="utf-8")
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> HTMLResponse:
+    return HTMLResponse(_ui_app_html())
+
+
+@app.get("/app", response_class=HTMLResponse)
+def ui_app() -> HTMLResponse:
+    return HTMLResponse(_ui_app_html())
 
 
 @app.get("/api/health")

--- a/tests/test_ui_server_api.py
+++ b/tests/test_ui_server_api.py
@@ -47,8 +47,13 @@ def test_api_grid_sorts_scores_with_none(reload_ui_server):
     assert desc_scores == [None, 90, 75]
 
 
-def test_index_serves_ui_html(reload_ui_server):
+def test_ui_app_endpoint_serves_html(reload_ui_server):
     module, _ = reload_ui_server
-    response = module.index()
-    assert response.status_code == 200
-    assert 'id="root"' in response.body.decode("utf-8")
+
+    root_response = module.index()
+    assert root_response.status_code == 200
+    assert 'id="root"' in root_response.body.decode("utf-8")
+
+    app_response = module.ui_app()
+    assert app_response.status_code == 200
+    assert 'id="root"' in app_response.body.decode("utf-8")


### PR DESCRIPTION
## Summary
- load the bundled UI HTML using a shared helper
- serve the UI document from both `/` and `/app`
- extend API tests to cover the new endpoint output

## Testing
- pytest tests/test_ui_server_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e3ad6ae8832f97a4987c42f6a8aa