### PR TITLE
Add FastAPI /ui endpoint for UI page

### DIFF
--- a/src/ui_server.py
+++ b/src/ui_server.py
@@ -102,6 +102,11 @@ def ui_app() -> HTMLResponse:
     return HTMLResponse(_ui_app_html())
 
 
+@app.get("/ui", response_class=HTMLResponse)
+def ui_route() -> HTMLResponse:
+    return HTMLResponse(_ui_app_html())
+
+
 @app.get("/api/health")
 def api_health() -> Dict[str, object]:
     return {"ok": True, "data_dir": str(DATA_DIR)}


### PR DESCRIPTION
## Summary
- add a FastAPI handler for `/ui` that returns the existing UI HTML

## Testing
- uvicorn src.ui_server:app --host 0.0.0.0 --port 8000
- curl -i http://127.0.0.1:8000/ui

------
https://chatgpt.com/codex/tasks/task_e_68d6f3e08f88832f9ffbebd9f914cef1