### PR TITLE
Add toolbar data clearing control and toast notifications

### DIFF
--- a/src/ui_app.html
+++ b/src/ui_app.html
@@ -24,7 +24,7 @@
 <div id="root"></div>
 
 <script type="text/javascript">
-const {useState,useEffect,useMemo,useCallback,useRef,Fragment} = React;
+const {useState,useEffect,useMemo,useCallback,useRef,useContext,Fragment} = React;
 
 const DEFAULT_API_BASE = (() => {
   if (typeof window !== "undefined") {
@@ -95,6 +95,114 @@ const DEFAULT_COLUMNS = [
   {id:"delta.dias",label:"Delta Dias",type:"number"},
   {id:"motivos",label:"Motivos",type:"text"}
 ];
+
+const ToastContext = React.createContext(null);
+
+const TOAST_TONES = {
+  success: {border:"border-emerald-500/40", indicator:"bg-emerald-500", title:"text-emerald-900", description:"text-emerald-700"},
+  error: {border:"border-rose-500/40", indicator:"bg-rose-500", title:"text-rose-900", description:"text-rose-700"},
+  warning: {border:"border-amber-500/40", indicator:"bg-amber-500", title:"text-amber-900", description:"text-amber-700"},
+  info: {border:"border-slate-500/30", indicator:"bg-slate-500", title:"text-slate-900", description:"text-slate-600"}
+};
+
+function ToastViewport({toasts,removeToast}){
+  if(!toasts || !toasts.length){
+    return null;
+  }
+  return React.createElement("div",{className:"pointer-events-none fixed top-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2 px-4"},
+    toasts.map(toast=>{
+      if(!toast){
+        return null;
+      }
+      const tone = TOAST_TONES[toast.type] || TOAST_TONES.info;
+      return React.createElement("div",{key:toast.id,className:`pointer-events-auto rounded-xl border ${tone.border} bg-white shadow-soft`},
+        React.createElement("div",{className:"flex items-start gap-3 p-4"},
+          React.createElement("span",{className:`mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${tone.indicator}`},""),
+          React.createElement("div",{className:"flex-1"},
+            toast.title ? React.createElement("p",{className:`text-sm font-semibold ${tone.title}`},toast.title) : null,
+            toast.description ? React.createElement("p",{className:`mt-1 text-sm ${tone.description}`},toast.description) : null
+          ),
+          React.createElement("button",{
+            type:"button",
+            onClick:()=>removeToast(toast.id),
+            className:"ml-2 text-xs font-semibold text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+          },"Fechar")
+        )
+      );
+    }).filter(Boolean)
+  );
+}
+
+function ToastProvider({children}){
+  const [toasts,setToasts] = useState([]);
+  const timeoutMap = useRef(new Map());
+
+  const clearTimeoutById = useCallback((id)=>{
+    const timeouts = timeoutMap.current;
+    if(!timeouts){
+      return;
+    }
+    const timeoutId = timeouts.get(id);
+    if(timeoutId){
+      clearTimeout(timeoutId);
+      timeouts.delete(id);
+    }
+  },[]);
+
+  const removeToast = useCallback((id)=>{
+    if(!id){
+      return;
+    }
+    setToasts(prev=>prev.filter(toast=>toast && toast.id !== id));
+    clearTimeoutById(id);
+  },[clearTimeoutById]);
+
+  const addToast = useCallback((toast)=>{
+    if(!toast){
+      return null;
+    }
+    const id = toast.id || `toast_${Date.now().toString(36)}_${Math.random().toString(36).slice(2,8)}`;
+    const duration = typeof toast.duration === "number" ? toast.duration : 5000;
+    const entry = {
+      id,
+      type: toast.type || "info",
+      title: toast.title || null,
+      description: toast.description || null,
+      duration
+    };
+    setToasts(prev=>[...prev,entry]);
+    if(duration !== Infinity && duration > 0){
+      const timeoutId = setTimeout(()=>removeToast(id),duration);
+      timeoutMap.current.set(id,timeoutId);
+    }
+    return id;
+  },[removeToast]);
+
+  useEffect(()=>{
+    return ()=>{
+      const timeouts = timeoutMap.current;
+      if(timeouts){
+        timeouts.forEach(timeoutId=>clearTimeout(timeoutId));
+        timeouts.clear();
+      }
+    };
+  },[]);
+
+  const contextValue = useMemo(()=>({addToast,removeToast}),[addToast,removeToast]);
+
+  return React.createElement(ToastContext.Provider,{value:contextValue},
+    children,
+    React.createElement(ToastViewport,{toasts,removeToast})
+  );
+}
+
+function useToast(){
+  const ctx = useContext(ToastContext);
+  if(!ctx){
+    throw new Error("useToast deve ser usado dentro de ToastProvider");
+  }
+  return ctx;
+}
 
 function resolveApiUrl(base, path){
   if(!path){
@@ -243,8 +351,18 @@ function useApi(base=DEFAULT_API_BASE){
     const qs = new URLSearchParams(params).toString();
     const url = baseUrl + path + (qs?("?"+qs):"");
     const r = await fetch(url,{method:"DELETE"});
-    if(!r.ok) throw new Error(await r.text());
-    return await r.json();
+    const text = await r.text();
+    if(!r.ok){
+      throw new Error(text || r.statusText || "Request failed");
+    }
+    if(!text){
+      return {};
+    }
+    try{
+      return JSON.parse(text);
+    }catch(err){
+      return {raw:text};
+    }
   };
   const upload = async (path, formData)=>{
     const r = await fetch(baseUrl + path,{method:"POST",body:formData});
@@ -360,7 +478,7 @@ function UploadModal({open,onClose,onConfirm,submitting,error}){
   );
 }
 
-function Toolbar({stats,filters,onStatusFilter,onFilterChange,onReload,onExportX,onExportP,onClearFilters,loading,disabled}){
+function Toolbar({stats,filters,onStatusFilter,onFilterChange,onReload,onExportX,onExportP,onClearFilters,onClearData,clearing,loading,disabled}){
   const statusValue = (filters?.status || "");
   const statusCards = [
     {key:"TOTAL",label:"Total",valueKey:"TOTAL",statusValue:"",valueClass:"text-xl font-bold"},
@@ -411,6 +529,7 @@ function Toolbar({stats,filters,onStatusFilter,onFilterChange,onReload,onExportX
           React.createElement("button",{onClick:onClearFilters,disabled:disabled,className:"px-3 py-2 rounded-lg bg-slate-200 text-slate-700 hover:bg-slate-300 disabled:opacity-50 disabled:cursor-not-allowed"}, "Limpar filtros"),
           React.createElement("button",{onClick:onExportX,disabled:disabled,className:"px-3 py-2 rounded-lg bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, "Exportar Excel"),
           React.createElement("button",{onClick:onExportP,disabled:disabled,className:"px-3 py-2 rounded-lg bg-indigo-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, "Exportar PDF"),
+          React.createElement("button",{onClick:onClearData,disabled:disabled||clearing,className:"px-3 py-2 rounded-lg bg-rose-600 text-white hover:bg-rose-500 disabled:opacity-50 disabled:cursor-not-allowed"}, clearing?"Limpando...":"Limpar dados"),
           React.createElement("a",{href:"/files/",target:"_blank",className:"px-3 py-2 rounded-lg bg-slate-200"}, "Arquivos")
         )
       )
@@ -540,6 +659,7 @@ function computeToolbarStats(meta){
 
 function App(){
   const api = useApi(); // ajuste `window.UI_API_BASE` ou use ?api= para apontar para outro host/porta
+  const {addToast} = useToast();
   const [schema,setSchema] = useState(null);
   const [meta,setMeta] = useState(null);
   const [items,setItems] = useState([]);
@@ -558,6 +678,7 @@ function App(){
   const [currentJobId,setCurrentJobId] = useState(null);
   const [jobStatus,setJobStatus] = useState(null);
   const [jobCanceling,setJobCanceling] = useState(false);
+  const [clearingData,setClearingData] = useState(false);
   const normalizedJobStatus = String(jobStatus?.status || "").toLowerCase();
   const jobRunning = Boolean(currentJobId) && JOB_ACTIVE_STATES.has(normalizedJobStatus);
   const skipNextAutoLoad = useRef(false);
@@ -662,6 +783,40 @@ function App(){
     setFilters(cleared);
     loadGrid(0, cleared);
   },[loadGrid]);
+
+  const handleClearData = useCallback(async ()=>{
+    if(clearingData){
+      return;
+    }
+    const confirmed = window.confirm("Tem certeza que deseja limpar os dados processados? Esta ação não pode ser desfeita.");
+    if(!confirmed){
+      return;
+    }
+    setClearingData(true);
+    setError(null);
+    try{
+      await api.del("/api/data");
+      setMeta(null);
+      setItems([]);
+      setTotal(0);
+      setSelectedRow(null);
+      addToast({
+        type:"success",
+        title:"Dados limpos",
+        description:"Os dados processados foram removidos."
+      });
+    }catch(err){
+      console.error("Falha ao limpar dados", err);
+      const message = err && err.message ? err.message : String(err);
+      addToast({
+        type:"error",
+        title:"Erro ao limpar dados",
+        description: message
+      });
+    }finally{
+      setClearingData(false);
+    }
+  },[addToast, api, clearingData]);
 
   const exportX = async ()=>{
     try{
@@ -931,6 +1086,8 @@ function App(){
         onExportX: exportX,
         onExportP: exportP,
         onClearFilters: handleClearFilters,
+        onClearData: handleClearData,
+        clearing: clearingData,
         loading,
         disabled: jobRunning
       }),
@@ -957,7 +1114,7 @@ function App(){
 }
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(React.createElement(App));
+root.render(React.createElement(ToastProvider,null,React.createElement(App)));
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a toast provider to surface success and error notifications in the UI
- add a "Limpar dados" toolbar action that confirms, calls DELETE /api/data, and resets local state
- make the DELETE helper resilient to empty responses from the API

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d71480c9b8832fbcd94ab5254f1ad6