### PR TITLE
Add detailed step logging and metrics to pipeline runner

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -3,9 +3,12 @@
 import argparse
 import json
 import sys
+import time
 import unicodedata
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Sequence, Optional, Set
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Set
 
 # Ensure src/ is importable
 ROOT_DIR = Path(__file__).resolve().parent
@@ -210,14 +213,319 @@ def ensure_dir(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
 
 
-def call_step(name: str, func, args: Iterable[str]) -> None:
+@dataclass
+class StepMetrics:
+    rows_processed: Optional[int] = None
+    inconsistencies: List[str] = field(default_factory=list)
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def as_record(self) -> Dict[str, Any]:
+        record: Dict[str, Any] = {}
+        if self.rows_processed is not None:
+            record["rows_processed"] = self.rows_processed
+        record["inconsistencies"] = self.inconsistencies
+        if self.details:
+            record["details"] = self.details
+        return record
+
+
+@dataclass
+class StepContext:
+    name: str
+    args: List[str]
+    log_path: Optional[Path]
+    staging_dir: Path
+    normalized_dir: Path
+    match_dir: Path
+    out_dir: Path
+    start_time: datetime
+    end_time: datetime
+    duration_seconds: float
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StepDefinition:
+    name: str
+    func: Callable[[List[str]], int]
+    args: List[str]
+    log_path: Optional[Path] = None
+    metrics_collector: Optional[Callable[[StepContext], StepMetrics]] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+def append_jsonl(path: Path, record: Dict[str, Any]) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def iter_jsonl(path: Path) -> Iterator[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, 1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                yield json.loads(text)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive path
+                raise ValueError(f"Invalid JSON on line {line_no} of {path.name}: {exc}") from exc
+
+
+def count_csv_rows(path: Path) -> Optional[int]:
+    if not path.exists():
+        return None
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        total = sum(1 for _ in handle)
+    if total <= 0:
+        return 0
+    return max(total - 1, 0)
+
+
+def count_jsonl_rows(path: Path) -> Optional[int]:
+    if not path.exists():
+        return None
+    count = 0
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                count += 1
+    return count
+
+
+def loader_metrics(context: StepContext) -> StepMetrics:
+    metrics = StepMetrics(rows_processed=0, details={"files_processed": 0})
+    path = context.log_path
+    if path is None or not path.exists():
+        metrics.rows_processed = None
+        metrics.details.pop("files_processed", None)
+        metrics.inconsistencies.append("Arquivo de log da etapa ausente.")
+        return metrics
+
+    rows_total = 0
+    files = 0
+    inconsistencies: List[str] = []
+    for record in iter_jsonl(path):
+        files += 1
+        rows_total += int(record.get("rows") or 0)
+        status = str(record.get("status") or "").lower()
+        if status and status not in {"written", "dry-run"}:
+            source = Path(str(record.get("input") or "")).name or "(desconhecido)"
+            inconsistencies.append(f"{source}: status={status}")
+        details = record.get("details") or {}
+        reason = details.get("reason")
+        if reason and status != "written":
+            source = Path(str(record.get("input") or "")).name or "(desconhecido)"
+            inconsistencies.append(f"{source}: {reason}")
+
+    metrics.rows_processed = rows_total
+    metrics.details["files_processed"] = files
+    metrics.inconsistencies = inconsistencies
+    return metrics
+
+
+def normalizer_metrics(context: StepContext) -> StepMetrics:
+    metrics = StepMetrics(rows_processed=0, details={"datasets": {}})
+    path = context.log_path
+    if path is None or not path.exists():
+        metrics.rows_processed = None
+        metrics.details.pop("datasets", None)
+        metrics.inconsistencies.append("Arquivo de log da etapa ausente.")
+        return metrics
+
+    rows_total = 0
+    datasets: Dict[str, int] = {}
+    inconsistencies: List[str] = []
+    for record in iter_jsonl(path):
+        dataset = str(record.get("dataset") or "desconhecido")
+        rows = int(record.get("rows") or 0)
+        rows_total += rows
+        datasets[dataset] = rows
+        if not record.get("csv", False):
+            inconsistencies.append(f"{dataset}: CSV não gerado")
+        if not record.get("parquet", False):
+            inconsistencies.append(f"{dataset}: Parquet não gerado")
+
+    metrics.rows_processed = rows_total
+    metrics.details["datasets"] = datasets
+    metrics.inconsistencies = inconsistencies
+    return metrics
+
+
+def matcher_metrics(context: StepContext) -> StepMetrics:
+    grid_path = Path(context.extra.get("grid", context.match_dir / "reconc_grid.csv"))
+    sem_fonte_path = Path(context.extra.get("sem_fonte", context.match_dir / "reconc_sem_fonte.csv"))
+    sem_sucessor_path = Path(context.extra.get("sem_sucessor", context.match_dir / "reconc_sem_sucessor.csv"))
+    metrics = StepMetrics(details={
+        "grid": str(grid_path),
+        "sem_fonte": str(sem_fonte_path),
+        "sem_sucessor": str(sem_sucessor_path),
+    })
+
+    rows = count_csv_rows(grid_path)
+    if rows is None:
+        metrics.inconsistencies.append("Grid principal não encontrada após o matcher.")
+    else:
+        metrics.rows_processed = rows
+
+    log_path = context.log_path
+    if log_path is not None and log_path.exists():
+        metrics.details["log_entries"] = count_jsonl_rows(log_path)
+    else:
+        metrics.inconsistencies.append("match_log.jsonl ausente.")
+
+    sem_fonte_rows = count_csv_rows(sem_fonte_path)
+    if sem_fonte_rows is None:
+        metrics.inconsistencies.append("Arquivo reconc_sem_fonte.csv não encontrado.")
+    elif sem_fonte_rows > 0:
+        metrics.inconsistencies.append(f"Linhas sem fonte: {sem_fonte_rows}")
+        metrics.details["sem_fonte_rows"] = sem_fonte_rows
+    else:
+        metrics.details["sem_fonte_rows"] = 0
+
+    sem_sucessor_rows = count_csv_rows(sem_sucessor_path)
+    if sem_sucessor_rows is None:
+        metrics.inconsistencies.append("Arquivo reconc_sem_sucessor.csv não encontrado.")
+    elif sem_sucessor_rows > 0:
+        metrics.inconsistencies.append(f"Linhas sem Sucessor: {sem_sucessor_rows}")
+        metrics.details["sem_sucessor_rows"] = sem_sucessor_rows
+    else:
+        metrics.details["sem_sucessor_rows"] = 0
+
+    return metrics
+
+
+def issues_metrics(context: StepContext) -> StepMetrics:
+    issues_path = Path(context.extra.get("issues"))
+    grid_out_path = Path(context.extra.get("grid_out"))
+    metrics = StepMetrics(details={
+        "issues": str(issues_path),
+        "grid_out": str(grid_out_path),
+    })
+
+    rows = count_csv_rows(grid_out_path)
+    if rows is None:
+        metrics.inconsistencies.append("Grid anotada não encontrada após issues_engine.")
+    else:
+        metrics.rows_processed = rows
+
+    issues_count = count_jsonl_rows(issues_path)
+    if issues_count is None:
+        metrics.inconsistencies.append("Arquivo issues.jsonl não encontrado.")
+    else:
+        metrics.details["issues_emitted"] = issues_count
+        if issues_count > 0:
+            metrics.inconsistencies.append(f"Issues emitidas: {issues_count}")
+
+    return metrics
+
+
+def ui_metrics(context: StepContext) -> StepMetrics:
+    jsonl_path = context.log_path
+    meta_path = Path(context.extra.get("meta"))
+    metrics = StepMetrics(details={"meta": str(meta_path)})
+
+    if jsonl_path is None or not jsonl_path.exists():
+        metrics.rows_processed = None
+        metrics.inconsistencies.append("Dataset JSONL da UI não foi gerado.")
+    else:
+        count = count_jsonl_rows(jsonl_path) or 0
+        metrics.rows_processed = count
+        metrics.details["jsonl"] = str(jsonl_path)
+
+    if not meta_path.exists():
+        metrics.inconsistencies.append("Arquivo ui_meta.json não encontrado.")
+    else:
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            metrics.inconsistencies.append(f"ui_meta.json inválido: {exc}")
+        else:
+            metrics.details["meta_stats_keys"] = sorted((meta.get("stats") or {}).keys())
+
+    return metrics
+
+
+def call_step(step: StepDefinition, pipeline_log: Path, *, staging_dir: Path, normalized_dir: Path, match_dir: Path, out_dir: Path) -> None:
     _ensure_not_cancelled()
-    sys.stdout.write(f"[pipeline] Running {name}...\n")
-    exit_code = func(list(args))
+    args = list(step.args)
+    sys.stdout.write(f"[pipeline] Running {step.name}...\n")
+
+    start_time = datetime.now(timezone.utc)
+    start_perf = time.perf_counter()
+    append_jsonl(
+        pipeline_log,
+        {
+            "step": step.name,
+            "event": "start",
+            "timestamp": start_time.isoformat(),
+            "args": args,
+        },
+    )
+
+    exit_code = step.func(args)
+    end_perf = time.perf_counter()
+    end_time = datetime.now(timezone.utc)
+    duration = end_perf - start_perf
+
     if exit_code != 0:
-        sys.stderr.write(f"[pipeline] Step '{name}' failed with exit code {exit_code}.\n")
+        append_jsonl(
+            pipeline_log,
+            {
+                "step": step.name,
+                "event": "end",
+                "timestamp": end_time.isoformat(),
+                "duration_seconds": duration,
+                "status": "failed",
+                "exit_code": exit_code,
+            },
+        )
+        sys.stderr.write(f"[pipeline] Step '{step.name}' failed with exit code {exit_code}.\n")
         sys.exit(exit_code)
-    sys.stdout.write(f"[pipeline] Step '{name}' completed.\n")
+
+    context = StepContext(
+        name=step.name,
+        args=args,
+        log_path=step.log_path,
+        staging_dir=staging_dir,
+        normalized_dir=normalized_dir,
+        match_dir=match_dir,
+        out_dir=out_dir,
+        start_time=start_time,
+        end_time=end_time,
+        duration_seconds=duration,
+        extra=step.extra,
+    )
+
+    metrics = StepMetrics()
+    if step.metrics_collector is not None:
+        try:
+            metrics = step.metrics_collector(context)
+        except Exception as exc:  # pragma: no cover - defensive path
+            metrics = StepMetrics()
+            metrics.inconsistencies.append(f"Falha ao coletar métricas: {exc}")
+
+    append_jsonl(
+        pipeline_log,
+        {
+            "step": step.name,
+            "event": "end",
+            "timestamp": end_time.isoformat(),
+            "duration_seconds": duration,
+            "status": "ok",
+            **metrics.as_record(),
+        },
+    )
+
+    rows_text = "?" if metrics.rows_processed is None else str(metrics.rows_processed)
+    inconsistencies_count = len(metrics.inconsistencies)
+    sys.stdout.write(
+        f"[pipeline] Step '{step.name}' completed in {duration:.2f}s | linhas={rows_text} | inconsistências={inconsistencies_count}.\n"
+    )
+    if metrics.inconsistencies:
+        for item in metrics.inconsistencies:
+            sys.stdout.write(f"[pipeline]   - {item}\n")
+
     _ensure_not_cancelled()
 
 
@@ -257,93 +565,192 @@ def main(argv: Sequence[str] | None = None) -> int:
     ensure_dir(normalized_dir)
     ensure_dir(match_dir)
 
-    try:
-        loader_args: List[str] = [
-            "--inputs",
-            *[str(path) for path in (
-                input_paths["sucessor"],
-                input_paths["entradas"],
-                input_paths["saidas"],
-                input_paths["servicos"],
-                input_paths["fornecedores"],
-                input_paths["plano"],
-            )],
-            "--profiles",
-            str(profiles_path),
-            "--staging",
-            str(staging_dir),
-            "--log",
-            str(log_dir / "loader.jsonl"),
-        ]
-        call_step("loader", loader_main, loader_args)
+    pipeline_log_path = log_dir / "pipeline.jsonl"
+    if pipeline_log_path.exists():
+        pipeline_log_path.unlink()
 
-        normalizer_args: List[str] = [
-            "--staging",
-            str(staging_dir),
-            "--out",
-            str(normalized_dir),
-            "--profiles",
-            str(profiles_path),
-            "--tokens",
-            str(tokens_path),
-            "--log",
-            str(log_dir / "normalizer.jsonl"),
-        ]
-        call_step("normalizer", normalizer_main, normalizer_args)
+    steps: List[StepDefinition] = []
 
-        matcher_args: List[str] = [
-            "--sucessor",
-            str(choose_normalized_table(normalized_dir, "sucessor")),
-            "--entradas",
-            str(choose_normalized_table(normalized_dir, "entradas")),
-            "--saidas",
-            str(choose_normalized_table(normalized_dir, "saidas")),
-            "--servicos",
-            str(choose_normalized_table(normalized_dir, "servicos")),
-            "--cfg-pesos",
-            str(matching_path),
-            "--cfg-tokens",
-            str(tokens_path),
-            "--cfop-map",
-            str(cfop_path),
-            "--out",
-            str(match_dir),
-            "--log",
-            str(match_dir / "match_log.jsonl"),
-        ]
-        call_step("matcher", matcher_main, matcher_args)
+    loader_log = log_dir / "loader.jsonl"
+    loader_args: List[str] = [
+        "--inputs",
+        *[str(path) for path in (
+            input_paths["sucessor"],
+            input_paths["entradas"],
+            input_paths["saidas"],
+            input_paths["servicos"],
+            input_paths["fornecedores"],
+            input_paths["plano"],
+        )],
+        "--profiles",
+        str(profiles_path),
+        "--staging",
+        str(staging_dir),
+        "--log",
+        str(loader_log),
+    ]
+    steps.append(
+        StepDefinition(
+            name="loader",
+            func=loader_main,
+            args=loader_args,
+            log_path=loader_log,
+            metrics_collector=loader_metrics,
+            extra={
+                "inputs": [
+                    str(input_paths["sucessor"]),
+                    str(input_paths["entradas"]),
+                    str(input_paths["saidas"]),
+                    str(input_paths["servicos"]),
+                    str(input_paths["fornecedores"]),
+                    str(input_paths["plano"]),
+                ]
+            },
+        )
+    )
 
-        issues_args: List[str] = [
+    normalizer_log = log_dir / "normalizer.jsonl"
+    normalizer_args: List[str] = [
+        "--staging",
+        str(staging_dir),
+        "--out",
+        str(normalized_dir),
+        "--profiles",
+        str(profiles_path),
+        "--tokens",
+        str(tokens_path),
+        "--log",
+        str(normalizer_log),
+    ]
+    steps.append(
+        StepDefinition(
+            name="normalizer",
+            func=normalizer_main,
+            args=normalizer_args,
+            log_path=normalizer_log,
+            metrics_collector=normalizer_metrics,
+        )
+    )
+
+    matcher_log = match_dir / "match_log.jsonl"
+    matcher_args: List[str] = [
+        "--sucessor",
+        str(choose_normalized_table(normalized_dir, "sucessor")),
+        "--entradas",
+        str(choose_normalized_table(normalized_dir, "entradas")),
+        "--saidas",
+        str(choose_normalized_table(normalized_dir, "saidas")),
+        "--servicos",
+        str(choose_normalized_table(normalized_dir, "servicos")),
+        "--cfg-pesos",
+        str(matching_path),
+        "--cfg-tokens",
+        str(tokens_path),
+        "--cfop-map",
+        str(cfop_path),
+        "--out",
+        str(match_dir),
+        "--log",
+        str(matcher_log),
+    ]
+    steps.append(
+        StepDefinition(
+            name="matcher",
+            func=matcher_main,
+            args=matcher_args,
+            log_path=matcher_log,
+            metrics_collector=matcher_metrics,
+            extra={
+                "grid": match_dir / "reconc_grid.csv",
+                "sem_fonte": match_dir / "reconc_sem_fonte.csv",
+                "sem_sucessor": match_dir / "reconc_sem_sucessor.csv",
+            },
+        )
+    )
+
+    issues_out = match_dir / "issues.jsonl"
+    issues_grid_out = match_dir / "reconc_grid_issues.csv"
+    issues_args: List[str] = [
+        "--grid",
+        str(match_dir / "reconc_grid.csv"),
+        "--rules",
+        str(issues_rules_path),
+        "--out-issues",
+        str(issues_out),
+        "--out-grid",
+        str(issues_grid_out),
+    ]
+    steps.append(
+        StepDefinition(
+            name="issues_engine",
+            func=issues_main,
+            args=issues_args,
+            metrics_collector=issues_metrics,
+            extra={
+                "issues": issues_out,
+                "grid_out": issues_grid_out,
+            },
+        )
+    )
+
+    if not args.skip_ui:
+        ui_jsonl = out_dir / "ui_grid.jsonl"
+        ui_meta = out_dir / "ui_meta.json"
+        ui_args: List[str] = [
             "--grid",
-            str(match_dir / "reconc_grid.csv"),
-            "--rules",
-            str(issues_rules_path),
-            "--out-issues",
-            str(match_dir / "issues.jsonl"),
-            "--out-grid",
-            str(match_dir / "reconc_grid_issues.csv"),
+            str(issues_grid_out),
+            "--sem-fonte",
+            str(match_dir / "reconc_sem_fonte.csv"),
+            "--sem-sucessor",
+            str(match_dir / "reconc_sem_sucessor.csv"),
+            "--out-jsonl",
+            str(ui_jsonl),
+            "--meta",
+            str(ui_meta),
+            "--schema",
+            str(schema_path),
         ]
-        call_step("issues_engine", issues_main, issues_args)
+        steps.append(
+            StepDefinition(
+                name="ui_dataset_builder",
+                func=ui_dataset_main,
+                args=ui_args,
+                log_path=ui_jsonl,
+                metrics_collector=ui_metrics,
+                extra={"meta": ui_meta},
+            )
+        )
 
-        if not args.skip_ui:
-            ui_args: List[str] = [
-                "--grid",
-                str(match_dir / "reconc_grid_issues.csv"),
-                "--sem-fonte",
-                str(match_dir / "reconc_sem_fonte.csv"),
-                "--sem-sucessor",
-                str(match_dir / "reconc_sem_sucessor.csv"),
-                "--out-jsonl",
-                str(out_dir / "ui_grid.jsonl"),
-                "--meta",
-                str(out_dir / "ui_meta.json"),
-                "--schema",
-                str(schema_path),
-            ]
-            call_step("ui_dataset_builder", ui_dataset_main, ui_args)
+    try:
+        for step in steps:
+            call_step(
+                step,
+                pipeline_log_path,
+                staging_dir=staging_dir,
+                normalized_dir=normalized_dir,
+                match_dir=match_dir,
+                out_dir=out_dir,
+            )
     except PipelineCancelled:
+        append_jsonl(
+            pipeline_log_path,
+            {
+                "event": "pipeline",
+                "status": "cancelled",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
         sys.stderr.write("[pipeline] Execution cancelled before completion.\n")
         return 3
+
+    append_jsonl(
+        pipeline_log_path,
+        {
+            "event": "pipeline",
+            "status": "ok",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+    )
 
     sys.stdout.write("[pipeline] All steps completed successfully.\n")
     return 0


### PR DESCRIPTION
## Summary
- add structured step definitions to the pipeline runner so each stage records start/end timestamps, duration and metrics
- collect per-step metrics from existing log files and outputs, including rows processed and inconsistencies, and append them to a pipeline.jsonl log
- restructure the main pipeline execution to use the new logging helpers while preserving existing CLI arguments

## Testing
- pytest tests/test_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68daa14ac550832f80accb2cfe573c5c