### PR TITLE
Add API version endpoint for backend status

### DIFF
--- a/tests/test_ui_server_api.py
+++ b/tests/test_ui_server_api.py
@@ -112,6 +112,26 @@ def test_manual_override_delete_removes_adjustment(reload_ui_server):
     assert row.get("original_status") in (None, "")
 
 
+def test_api_version_reports_status_and_dependencies(reload_ui_server):
+    module, data_dir = reload_ui_server
+    schema_path = data_dir / "ui_schema.json"
+    schema_path.write_text(json.dumps({"version": 1}), encoding="utf-8")
+
+    info = module.api_version()
+
+    assert info["app"]["title"] == module.APP_TITLE
+    dependencies = info["dependencies"]
+    assert "fastapi" in dependencies
+    assert dependencies["fastapi"] is None or isinstance(dependencies["fastapi"], str)
+
+    status = info["status"]
+    assert status["paths"]["data_dir"]["path"] == str(data_dir)
+    assert status["paths"]["data_dir"]["exists"] is True
+    assert status["paths"]["schema"]["exists"] is True
+    assert "timestamp" in status
+    assert status["jobs"]["running"] == 0
+
+
 def test_ui_app_endpoint_serves_html(reload_ui_server):
     module, _ = reload_ui_server
 


### PR DESCRIPTION
## Summary
- add helpers to collect dependency versions and runtime status for the FastAPI server
- expose a new `/api/version` endpoint so the UI can verify backend versions and environment paths
- add an automated test that validates the structure of the version response

## Testing
- pytest tests/test_ui_server_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dab58436f0832f919aecd9fa72491a