### PR TITLE
Add frontend internationalization support

### DIFF
--- a/src/static/i18n/pt-BR.json
+++ b/src/static/i18n/pt-BR.json
@@ -1,0 +1,191 @@
+{
+  "common": {
+    "close": "Fechar",
+    "cancel": "Cancelar",
+    "loading": "Carregando..."
+  },
+  "upload": {
+    "title": "Enviar CSVs",
+    "subtitle": "Selecione os arquivos CSV necessários para iniciar o processamento.",
+    "validation": {
+      "selectFile": "Selecione o arquivo de {label}."
+    },
+    "actions": {
+      "submitting": "Enviando...",
+      "submit": "Enviar e processar"
+    },
+    "fields": {
+      "sucessor": {
+        "label": "Sucessor (contábil)",
+        "hint": "Ex: sucessor.csv"
+      },
+      "entradas": {
+        "label": "Suprema Entradas",
+        "hint": "Ex: suprema_entradas.csv"
+      },
+      "saidas": {
+        "label": "Suprema Saídas",
+        "hint": "Ex: suprema_saidas.csv"
+      },
+      "servicos": {
+        "label": "Suprema Serviços",
+        "hint": "Ex: suprema_servicos.csv"
+      },
+      "fornecedores": {
+        "label": "Fornecedores",
+        "hint": "Ex: fornecedores.csv"
+      },
+      "plano": {
+        "label": "Plano de Contas",
+        "hint": "Ex: plano_contas.csv"
+      }
+    }
+  },
+  "job": {
+    "progress": {
+      "title": "Processamento em andamento (job {jobId})",
+      "status": "Status: {status}",
+      "downloadLogs": "Baixar logs",
+      "cancelRequested": "Cancelamento solicitado",
+      "canceling": "Cancelando...",
+      "cancel": "Cancelar",
+      "progress": "Progresso",
+      "logSize": "Log: {size} KB",
+      "cancelNotice": "Cancelamento em andamento — aguarde a finalização."
+    }
+  },
+  "toolbar": {
+    "cards": {
+      "total": "Total",
+      "ok": "OK",
+      "alert": "Alertas",
+      "divergence": "Divergências",
+      "noSource": "Sem Fonte",
+      "noSuccessor": "Sem Sucessor"
+    },
+    "filters": {
+      "statusAll": "Status — todos",
+      "sourceAll": "Fonte — todas",
+      "cfop": "CFOP",
+      "search": "Buscar (histórico, doc, tags)..."
+    },
+    "actions": {
+      "refresh": "Atualizar",
+      "clearFilters": "Limpar filtros",
+      "exportJson": "Exportar JSON",
+      "exportExcel": "Exportar Excel",
+      "exportPdf": "Exportar PDF",
+      "clearing": "Limpando...",
+      "clearData": "Limpar dados",
+      "files": "Arquivos"
+    }
+  },
+  "inspector": {
+    "title": "Detalhes da seleção",
+    "fields": {
+      "currentStatus": "Status atual",
+      "strategy": "Estratégia",
+      "score": "Score",
+      "sucessor": "Sucessor",
+      "source": "Fonte",
+      "deltaValue": "Delta Valor",
+      "deltaDays": "Delta Dias",
+      "reasons": "Motivos"
+    },
+    "actions": {
+      "markOk": "Marcar OK",
+      "markDivergence": "Marcar Divergência",
+      "reset": "Reverter"
+    }
+  },
+  "table": {
+    "headers": {
+      "status": "Status",
+      "actions": "Ações"
+    },
+    "actions": {
+      "markOk": "Marcar OK",
+      "markDivergence": "Marcar Divergência",
+      "reset": "Reverter"
+    },
+    "loading": {
+      "title": "Carregando dados...",
+      "description": "Estamos preparando a grade para exibição."
+    },
+    "empty": {
+      "title": "Nenhum registro encontrado.",
+      "description": "Ajuste os filtros ou processe novos dados."
+    },
+    "columns": {
+      "strategy": "Regra",
+      "score": "Score",
+      "sData": "Data (S)",
+      "sDebito": "Débito",
+      "sCredito": "Crédito",
+      "sDoc": "Nº Docto (S)",
+      "sValor": "Valor (S)",
+      "fDoc": "Nº Docto (F)",
+      "fValor": "Valor (F)",
+      "cfop": "CFOP",
+      "deltaValor": "Delta Valor",
+      "deltaDias": "Delta Dias",
+      "motivos": "Motivos"
+    }
+  },
+  "paginator": {
+    "summary": "Mostrando {start}-{end} de {total}",
+    "page": "Página {page}/{pages}",
+    "previous": "Anterior",
+    "next": "Próximo"
+  },
+  "toast": {
+    "defaults": {
+      "errorTitle": "Erro",
+      "errorDescription": "Ocorreu um erro inesperado.",
+      "warningTitle": "Aviso",
+      "warningDescription": "Verifique as informações exibidas."
+    }
+  },
+  "app": {
+    "notifications": {
+      "metaError": "Erro ao carregar metadados",
+      "gridError": "Erro ao carregar dados",
+      "gridErrorMessage": "Não foi possível carregar os dados da grade. Tente novamente.",
+      "clearSuccessTitle": "Dados limpos",
+      "clearSuccessMessage": "Os dados processados foram removidos.",
+      "clearErrorTitle": "Erro",
+      "clearErrorToastTitle": "Erro ao limpar dados",
+      "clearErrorFallback": "Não foi possível limpar os dados processados.",
+      "processingFailedTitle": "Processamento falhou",
+      "processingFailedMessage": "O processamento foi interrompido.",
+      "processingCancelledTitle": "Processamento cancelado",
+      "processingCancelledMessage": "O processamento foi interrompido antes da conclusão.",
+      "cancelProcessError": "Não foi possível cancelar o processamento",
+      "exportJsonError": "Erro ao exportar JSON",
+      "exportXlsxError": "Erro ao exportar XLSX",
+      "exportPdfError": "Erro ao exportar PDF",
+      "processStartError": "Erro ao iniciar processamento",
+      "uploadError": "Erro no envio de arquivos",
+      "manualSaveError": "Falha ao salvar ajuste manual",
+      "manualRemoveError": "Falha ao remover ajuste manual"
+    },
+    "confirm": {
+      "clearData": "Tem certeza que deseja limpar os dados processados? Esta ação não pode ser desfeita."
+    },
+    "empty": {
+      "filtered": "Nenhum registro encontrado para os filtros selecionados.",
+      "default": "Nenhum dado disponível no momento.",
+      "filteredHint": "Ajuste os filtros ou limpe os campos para visualizar outros resultados.",
+      "defaultHint": "Envie novos arquivos para gerar a grade de conferência."
+    },
+    "header": {
+      "title": "App de Conferência - UI",
+      "subtitle": "Carrega {file} do servidor local e exibe a grade com filtros e exports.",
+      "subtitleFile": "ui_grid.jsonl"
+    },
+    "actions": {
+      "processing": "Processando...",
+      "process": "Processar"
+    }
+  }
+}

--- a/src/ui_app.html
+++ b/src/ui_app.html
@@ -28,6 +28,69 @@
 <script type="text/javascript">
 const {useState,useEffect,useMemo,useCallback,useRef,useContext,Fragment} = React;
 
+const I18N_DEFAULT_LOCALE = (()=>{
+  if(typeof document !== "undefined" && document?.documentElement){
+    return document.documentElement.lang || "pt-BR";
+  }
+  return "pt-BR";
+})();
+
+const I18N_STATE = {
+  locale: I18N_DEFAULT_LOCALE,
+  translations: {}
+};
+
+function getTranslationByKey(key){
+  if(!key){
+    return undefined;
+  }
+  const parts = String(key).split(".");
+  let current = I18N_STATE.translations;
+  for(const part of parts){
+    if(current && Object.prototype.hasOwnProperty.call(current, part)){
+      current = current[part];
+    }else{
+      return undefined;
+    }
+  }
+  return typeof current === "string" ? current : undefined;
+}
+
+function translate(key, fallback, vars){
+  const raw = getTranslationByKey(key);
+  const base = typeof raw === "string" ? raw : (typeof fallback === "string" ? fallback : String(key));
+  if(!vars){
+    return base;
+  }
+  return base.replace(/\{([^}]+)\}/g,(match,token)=>{
+    if(Object.prototype.hasOwnProperty.call(vars, token)){
+      const value = vars[token];
+      return value == null ? "" : String(value);
+    }
+    return match;
+  });
+}
+
+const t = (key, fallback, vars)=> translate(key, fallback, vars);
+
+async function loadTranslations(locale){
+  const target = locale || I18N_DEFAULT_LOCALE;
+  const url = `static/i18n/${target}.json`;
+  try{
+    const response = await fetch(url);
+    if(!response.ok){
+      throw new Error(`Failed to load translations for ${target}`);
+    }
+    const data = await response.json();
+    I18N_STATE.locale = target;
+    I18N_STATE.translations = data || {};
+  }catch(err){
+    console.warn("Não foi possível carregar traduções:", err);
+    I18N_STATE.locale = target;
+    I18N_STATE.translations = {};
+  }
+}
+
 const DEFAULT_API_BASE = (() => {
   if (typeof window !== "undefined") {
     if (typeof window.UI_API_BASE !== "undefined") {
@@ -72,30 +135,30 @@ function createDefaultFilters(){
 }
 
 const REQUIRED_UPLOADS = [
-  {type: "sucessor", label: "Sucessor (contábil)", hint: "Ex: sucessor.csv"},
-  {type: "entradas", label: "Suprema Entradas", hint: "Ex: suprema_entradas.csv"},
-  {type: "saidas", label: "Suprema Saídas", hint: "Ex: suprema_saidas.csv"},
-  {type: "servicos", label: "Suprema Serviços", hint: "Ex: suprema_servicos.csv"},
-  {type: "fornecedores", label: "Fornecedores", hint: "Ex: fornecedores.csv"},
-  {type: "plano", label: "Plano de Contas", hint: "Ex: plano_contas.csv"}
+  {type: "sucessor", labelKey: "upload.fields.sucessor.label", labelFallback: "Sucessor (contábil)", hintKey: "upload.fields.sucessor.hint", hintFallback: "Ex: sucessor.csv"},
+  {type: "entradas", labelKey: "upload.fields.entradas.label", labelFallback: "Suprema Entradas", hintKey: "upload.fields.entradas.hint", hintFallback: "Ex: suprema_entradas.csv"},
+  {type: "saidas", labelKey: "upload.fields.saidas.label", labelFallback: "Suprema Saídas", hintKey: "upload.fields.saidas.hint", hintFallback: "Ex: suprema_saidas.csv"},
+  {type: "servicos", labelKey: "upload.fields.servicos.label", labelFallback: "Suprema Serviços", hintKey: "upload.fields.servicos.hint", hintFallback: "Ex: suprema_servicos.csv"},
+  {type: "fornecedores", labelKey: "upload.fields.fornecedores.label", labelFallback: "Fornecedores", hintKey: "upload.fields.fornecedores.hint", hintFallback: "Ex: fornecedores.csv"},
+  {type: "plano", labelKey: "upload.fields.plano.label", labelFallback: "Plano de Contas", hintKey: "upload.fields.plano.hint", hintFallback: "Ex: plano_contas.csv"}
 ];
 
 const JOB_ACTIVE_STATES = new Set(["queued","running","pending","processing","in_progress","cancelling"]);
 
 const DEFAULT_COLUMNS = [
-  {id:"strategy",label:"Regra",type:"text"},
-  {id:"score",label:"Score",type:"number"},
-  {id:"S.data",label:"Data (S)",type:"date"},
-  {id:"S.debito",label:"Debito",type:"text"},
-  {id:"S.credito",label:"Credito",type:"text"},
-  {id:"S.doc",label:"No Docto (S)",type:"text"},
-  {id:"S.valor",label:"Valor (S)",type:"money"},
-  {id:"F.doc",label:"No Docto (F)",type:"text"},
-  {id:"F.valor",label:"Valor (F)",type:"money"},
-  {id:"F.cfop",label:"CFOP",type:"text"},
-  {id:"delta.valor",label:"Delta Valor",type:"money"},
-  {id:"delta.dias",label:"Delta Dias",type:"number"},
-  {id:"motivos",label:"Motivos",type:"text"}
+  {id:"strategy",labelKey:"table.columns.strategy", labelFallback:"Regra",type:"text"},
+  {id:"score",labelKey:"table.columns.score", labelFallback:"Score",type:"number"},
+  {id:"S.data",labelKey:"table.columns.sData", labelFallback:"Data (S)",type:"date"},
+  {id:"S.debito",labelKey:"table.columns.sDebito", labelFallback:"Débito",type:"text"},
+  {id:"S.credito",labelKey:"table.columns.sCredito", labelFallback:"Crédito",type:"text"},
+  {id:"S.doc",labelKey:"table.columns.sDoc", labelFallback:"Nº Docto (S)",type:"text"},
+  {id:"S.valor",labelKey:"table.columns.sValor", labelFallback:"Valor (S)",type:"money"},
+  {id:"F.doc",labelKey:"table.columns.fDoc", labelFallback:"Nº Docto (F)",type:"text"},
+  {id:"F.valor",labelKey:"table.columns.fValor", labelFallback:"Valor (F)",type:"money"},
+  {id:"F.cfop",labelKey:"table.columns.cfop", labelFallback:"CFOP",type:"text"},
+  {id:"delta.valor",labelKey:"table.columns.deltaValor", labelFallback:"Delta Valor",type:"money"},
+  {id:"delta.dias",labelKey:"table.columns.deltaDias", labelFallback:"Delta Dias",type:"number"},
+  {id:"motivos",labelKey:"table.columns.motivos", labelFallback:"Motivos",type:"text"}
 ];
 
 const ToastContext = React.createContext(null);
@@ -128,7 +191,7 @@ function ToastViewport({toasts,removeToast}){
             type:"button",
             onClick:()=>removeToast(toast.id),
             className:"ml-2 text-xs font-semibold text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
-          },"Fechar")
+          },t("common.close","Fechar"))
         )
       );
     }).filter(Boolean)
@@ -225,6 +288,15 @@ function JobProgressPanel({jobId,status,apiBase,onCancel,canceling}){
   }
   const normalized = String(status.status || "").toLowerCase();
   const progress = status.progress || {};
+  const statusLabelValue = (status.status || "").replace(/_/g," ");
+  const headingText = t("job.progress.title","Processamento em andamento (job {jobId})",{jobId});
+  const statusText = t("job.progress.status","Status: {status}",{status: statusLabelValue});
+  const downloadLogsLabel = t("job.progress.downloadLogs","Baixar logs");
+  const cancelRequestedLabel = t("job.progress.cancelRequested","Cancelamento solicitado");
+  const cancelingLabel = t("job.progress.canceling","Cancelando...");
+  const cancelLabel = t("job.progress.cancel","Cancelar");
+  const progressLabel = t("job.progress.progress","Progresso");
+  const cancelNotice = t("job.progress.cancelNotice","Cancelamento em andamento — aguarde a finalização.");
   let percentValue = null;
   if(progress && Object.prototype.hasOwnProperty.call(progress,"percent")){
     const raw = progress.percent;
@@ -295,21 +367,21 @@ function JobProgressPanel({jobId,status,apiBase,onCancel,canceling}){
     React.createElement("div",{className:"mb-4 rounded-xl border border-indigo-200 bg-white p-4 shadow-soft"},
       React.createElement("div",{className:"flex flex-col gap-2 md:flex-row md:items-center md:justify-between"},
         React.createElement("div",{className:"space-y-1"},
-          React.createElement("p",{className:"text-sm font-medium text-indigo-900"},`Processamento em andamento (job ${jobId})`),
-          React.createElement("p",{className:"text-xs uppercase tracking-wide text-indigo-600"},`Status: ${(status.status || "").replace(/_/g," ")}`)
+          React.createElement("p",{className:"text-sm font-medium text-indigo-900"}, headingText),
+          React.createElement("p",{className:"text-xs uppercase tracking-wide text-indigo-600"}, statusText)
         ),
         React.createElement("div",{className:"flex items-center gap-2"},
-          logUrl && React.createElement("a",{href:logUrl,target:"_blank",rel:"noopener",className:"text-sm font-medium text-indigo-600 hover:text-indigo-500"},"Baixar logs"),
+          logUrl && React.createElement("a",{href:logUrl,target:"_blank",rel:"noopener",className:"text-sm font-medium text-indigo-600 hover:text-indigo-500"},downloadLogsLabel),
           React.createElement("button",{
             onClick:onCancel,
             disabled:disableCancel || canceling,
             className:"rounded-lg border border-indigo-500 px-3 py-1 text-sm font-semibold text-indigo-600 hover:bg-indigo-50 disabled:cursor-not-allowed disabled:border-slate-300 disabled:text-slate-400"
-          }, cancelRequested ? "Cancelamento solicitado" : (canceling ? "Cancelando..." : "Cancelar"))
+          }, cancelRequested ? cancelRequestedLabel : (canceling ? cancelingLabel : cancelLabel))
         )
       ),
       percentValue !== null && React.createElement("div",{className:"mt-4"},
         React.createElement("div",{className:"mb-1 flex justify-between text-xs text-slate-500"},
-          React.createElement("span",null,"Progresso"),
+          React.createElement("span",null,progressLabel),
           React.createElement("span",null,
             percentText,
             completed !== null && total !== null ? ` · ${completed}/${total}` : ""
@@ -324,8 +396,8 @@ function JobProgressPanel({jobId,status,apiBase,onCancel,canceling}){
       steps.length ? React.createElement("div",{className:"mt-4 max-h-48 overflow-y-auto rounded-lg bg-slate-50 p-3"},
         React.createElement("ol",{className:"space-y-1"}, steps.slice(-12).map(renderStep).filter(Boolean))
       ) : null,
-      status.log_size ? React.createElement("p",{className:"mt-3 text-xs text-slate-400"}, `Log: ${(status.log_size/1024).toFixed(1)} KB`) : null,
-      cancelRequested ? React.createElement("p",{className:"mt-3 text-xs text-amber-600"},"Cancelamento em andamento — aguarde a finalização.") : null
+      status.log_size ? React.createElement("p",{className:"mt-3 text-xs text-slate-400"}, t("job.progress.logSize","Log: {size} KB",{size:(status.log_size/1024).toFixed(1)})) : null,
+      cancelRequested ? React.createElement("p",{className:"mt-3 text-xs text-amber-600"},cancelNotice) : null
     )
   );
 }
@@ -452,7 +524,10 @@ function UploadModal({open,onClose,onConfirm,submitting,error}){
     const requiredMissing = REQUIRED_UPLOADS.filter(item=>!files[item.type]);
     if(requiredMissing.length){
       setMissing(requiredMissing.map(item=>item.type));
-      setMessages(requiredMissing.map(item=>`Selecione o arquivo de ${item.label}.`));
+      setMessages(requiredMissing.map(item=>{
+        const labelText = t(item.labelKey,item.labelFallback);
+        return t("upload.validation.selectFile","Selecione o arquivo de {label}.",{label: labelText});
+      }));
       return;
     }
     setMessages([]);
@@ -480,17 +555,19 @@ function UploadModal({open,onClose,onConfirm,submitting,error}){
         ),
         React.createElement("form",{onSubmit:handleSubmit,className:"p-6 md:p-8"},
           React.createElement("div",{className:"mb-6 space-y-2"},
-            React.createElement("h3",{className:"text-xl font-semibold text-slate-900"},"Enviar CSVs"),
-            React.createElement("p",{className:"text-sm text-slate-600"},"Selecione os arquivos CSV necessários para iniciar o processamento."),
+            React.createElement("h3",{className:"text-xl font-semibold text-slate-900"},t("upload.title","Enviar CSVs")),
+            React.createElement("p",{className:"text-sm text-slate-600"},t("upload.subtitle","Selecione os arquivos CSV necessários para iniciar o processamento.")),
           ),
           React.createElement("div",{className:"grid gap-4"},
             REQUIRED_UPLOADS.map(item=>{
               const hasError = missing.includes(item.type);
               const borderClass = hasError ? "border-rose-400 focus:border-rose-500 focus:ring-rose-200" : "border-slate-200 focus:border-slate-400 focus:ring-slate-200";
+              const labelText = t(item.labelKey,item.labelFallback);
+              const hintText = t(item.hintKey,item.hintFallback);
               return React.createElement("label",{key:item.type,className:"flex flex-col gap-2 rounded-xl border bg-slate-50/60 p-4"},
                 React.createElement("div",{className:"flex flex-col"},
-                  React.createElement("span",{className:"text-sm font-semibold text-slate-700"}, item.label),
-                  React.createElement("span",{className:"text-xs text-slate-500"}, item.hint)
+                  React.createElement("span",{className:"text-sm font-semibold text-slate-700"}, labelText),
+                  React.createElement("span",{className:"text-xs text-slate-500"}, hintText)
                 ),
                 React.createElement("input",{
                   type:"file",
@@ -510,12 +587,12 @@ function UploadModal({open,onClose,onConfirm,submitting,error}){
               onClick:handleClose,
               disabled:submitting,
               className:"rounded-lg bg-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-300 disabled:opacity-60"
-            },"Cancelar"),
+            },t("common.cancel","Cancelar")),
             React.createElement("button",{
               type:"submit",
               disabled:submitting,
               className:"rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-            }, submitting?"Enviando...":"Enviar e processar")
+            }, submitting?t("upload.actions.submitting","Enviando..."):t("upload.actions.submit","Enviar e processar"))
           )
         )
       )
@@ -526,12 +603,12 @@ function UploadModal({open,onClose,onConfirm,submitting,error}){
 function Toolbar({stats,filters,onStatusFilter,onFilterChange,onReload,onExportJson,onExportX,onExportP,onClearFilters,onClearData,clearing,loading,disabled}){
   const statusValue = (filters?.status || "");
   const statusCards = [
-    {key:"TOTAL",label:"Total",valueKey:"TOTAL",statusValue:"",valueClass:"text-xl font-bold"},
-    {key:"OK",label:"OK",valueKey:"OK",statusValue:"OK",valueClass:"text-xl font-bold text-emerald-700"},
-    {key:"ALERTA",label:"Alertas",valueKey:"ALERTA",statusValue:"ALERTA",valueClass:"text-xl font-bold text-amber-700"},
-    {key:"DIVERGENCIA",label:"Divergências",valueKey:"DIVERGENCIA",statusValue:"DIVERGENCIA",valueClass:"text-xl font-bold text-rose-700"},
-    {key:"SEM_FONTE",label:"Sem Fonte",valueKey:"SEM_FONTE",statusValue:"SEM_FONTE",valueClass:"text-xl font-bold text-slate-700"},
-    {key:"SEM_SUCESSOR",label:"Sem Sucessor",valueKey:"SEM_SUCESSOR",statusValue:"SEM_SUCESSOR",valueClass:"text-xl font-bold text-slate-700"}
+    {key:"TOTAL",labelKey:"toolbar.cards.total",label:"Total",valueKey:"TOTAL",statusValue:"",valueClass:"text-xl font-bold"},
+    {key:"OK",labelKey:"toolbar.cards.ok",label:"OK",valueKey:"OK",statusValue:"OK",valueClass:"text-xl font-bold text-emerald-700"},
+    {key:"ALERTA",labelKey:"toolbar.cards.alert",label:"Alertas",valueKey:"ALERTA",statusValue:"ALERTA",valueClass:"text-xl font-bold text-amber-700"},
+    {key:"DIVERGENCIA",labelKey:"toolbar.cards.divergence",label:"Divergências",valueKey:"DIVERGENCIA",statusValue:"DIVERGENCIA",valueClass:"text-xl font-bold text-rose-700"},
+    {key:"SEM_FONTE",labelKey:"toolbar.cards.noSource",label:"Sem Fonte",valueKey:"SEM_FONTE",statusValue:"SEM_FONTE",valueClass:"text-xl font-bold text-slate-700"},
+    {key:"SEM_SUCESSOR",labelKey:"toolbar.cards.noSuccessor",label:"Sem Sucessor",valueKey:"SEM_SUCESSOR",statusValue:"SEM_SUCESSOR",valueClass:"text-xl font-bold text-slate-700"}
   ];
   return (
     React.createElement("div",{className:"flex flex-col gap-3 md:flex-row md:items-end md:justify-between mb-4"},
@@ -549,7 +626,7 @@ function Toolbar({stats,filters,onStatusFilter,onFilterChange,onReload,onExportJ
             role:"button",
             "aria-pressed": isActive
           },[
-            React.createElement("div",{key:"label",className:"text-xs text-slate-500"}, card.label),
+            React.createElement("div",{key:"label",className:"text-xs text-slate-500"}, t(card.labelKey,card.label)),
             React.createElement("div",{key:"value",className: card.valueClass}, stats?.[card.valueKey] ?? "—")
           ]);
         })
@@ -557,26 +634,26 @@ function Toolbar({stats,filters,onStatusFilter,onFilterChange,onReload,onExportJ
       React.createElement("div",{className:"flex flex-col gap-2 md:w-[520px]"},
         React.createElement("div",{className:"flex gap-2"},
           React.createElement("select",{className:"px-2 py-2 rounded-lg bg-white border w-40 disabled:opacity-50",value:filters.status,disabled,onChange:e=>onStatusFilter && onStatusFilter(e.target.value)},
-            React.createElement("option",{value:""},"Status — todos"),
+            React.createElement("option",{value:""},t("toolbar.filters.statusAll","Status — todos")),
             ["OK","ALERTA","DIVERGENCIA","SEM_FONTE","SEM_SUCESSOR"].map(s=>React.createElement("option",{key:s,value:s},s))
           ),
           React.createElement("select",{className:"px-2 py-2 rounded-lg bg-white border w-40 disabled:opacity-50",value:filters.fonte_tipo,disabled,onChange:e=>onFilterChange && onFilterChange("fonte_tipo", e.target.value)},
-            React.createElement("option",{value:""},"Fonte — todas"),
+            React.createElement("option",{value:""},t("toolbar.filters.sourceAll","Fonte — todas")),
             ["ENTRADA","SAIDA","SERVICO"].map(s=>React.createElement("option",{key:s,value:s},s))
           ),
-          React.createElement("input",{className:"px-3 py-2 rounded-lg bg-white border flex-1 disabled:opacity-50",placeholder:"CFOP",value:filters.cfop,disabled,onChange:e=>onFilterChange && onFilterChange("cfop", e.target.value)})
+          React.createElement("input",{className:"px-3 py-2 rounded-lg bg-white border flex-1 disabled:opacity-50",placeholder:t("toolbar.filters.cfop","CFOP"),value:filters.cfop,disabled,onChange:e=>onFilterChange && onFilterChange("cfop", e.target.value)})
         ),
         React.createElement("div",{className:"flex gap-2"},
-          React.createElement("input",{className:"px-3 py-2 rounded-lg bg-white border flex-1 disabled:opacity-50",placeholder:"Buscar (histórico, doc, tags)...",value:filters.q,disabled,onChange:e=>onFilterChange && onFilterChange("q", e.target.value),onKeyDown:e=>{if(e.key==="Escape"){ e.preventDefault(); e.stopPropagation(); if(onFilterChange){ onFilterChange("q",""); } e.target.blur(); }}}),
-          React.createElement("button",{onClick:onReload,disabled:loading||disabled,className:"px-3 py-2 rounded-lg bg-slate-900 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, loading?"Carregando...":"Atualizar")
+          React.createElement("input",{className:"px-3 py-2 rounded-lg bg-white border flex-1 disabled:opacity-50",placeholder:t("toolbar.filters.search","Buscar (histórico, doc, tags)..."),value:filters.q,disabled,onChange:e=>onFilterChange && onFilterChange("q", e.target.value),onKeyDown:e=>{if(e.key==="Escape"){ e.preventDefault(); e.stopPropagation(); if(onFilterChange){ onFilterChange("q",""); } e.target.blur(); }}}),
+          React.createElement("button",{onClick:onReload,disabled:loading||disabled,className:"px-3 py-2 rounded-lg bg-slate-900 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, loading?t("common.loading","Carregando..."):t("toolbar.actions.refresh","Atualizar"))
         ),
         React.createElement("div",{className:"flex gap-2"},
-          React.createElement("button",{onClick:onClearFilters,disabled:disabled,className:"px-3 py-2 rounded-lg bg-slate-200 text-slate-700 hover:bg-slate-300 disabled:opacity-50 disabled:cursor-not-allowed"}, "Limpar filtros"),
-          React.createElement("button",{onClick:onExportJson,disabled:disabled,className:"px-3 py-2 rounded-lg bg-amber-500 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, "Exportar JSON"),
-          React.createElement("button",{onClick:onExportX,disabled:disabled,className:"px-3 py-2 rounded-lg bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, "Exportar Excel"),
-          React.createElement("button",{onClick:onExportP,disabled:disabled,className:"px-3 py-2 rounded-lg bg-indigo-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, "Exportar PDF"),
-          React.createElement("button",{onClick:onClearData,disabled:disabled||clearing,className:"px-3 py-2 rounded-lg bg-rose-600 text-white hover:bg-rose-500 disabled:opacity-50 disabled:cursor-not-allowed"}, clearing?"Limpando...":"Limpar dados"),
-          React.createElement("a",{href:"/files/",target:"_blank",className:"px-3 py-2 rounded-lg bg-slate-200"}, "Arquivos")
+          React.createElement("button",{onClick:onClearFilters,disabled:disabled,className:"px-3 py-2 rounded-lg bg-slate-200 text-slate-700 hover:bg-slate-300 disabled:opacity-50 disabled:cursor-not-allowed"}, t("toolbar.actions.clearFilters","Limpar filtros")),
+          React.createElement("button",{onClick:onExportJson,disabled:disabled,className:"px-3 py-2 rounded-lg bg-amber-500 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, t("toolbar.actions.exportJson","Exportar JSON")),
+          React.createElement("button",{onClick:onExportX,disabled:disabled,className:"px-3 py-2 rounded-lg bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, t("toolbar.actions.exportExcel","Exportar Excel")),
+          React.createElement("button",{onClick:onExportP,disabled:disabled,className:"px-3 py-2 rounded-lg bg-indigo-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"}, t("toolbar.actions.exportPdf","Exportar PDF")),
+          React.createElement("button",{onClick:onClearData,disabled:disabled||clearing,className:"px-3 py-2 rounded-lg bg-rose-600 text-white hover:bg-rose-500 disabled:opacity-50 disabled:cursor-not-allowed"}, clearing?t("toolbar.actions.clearing","Limpando..."):t("toolbar.actions.clearData","Limpar dados")),
+          React.createElement("a",{href:"/files/",target:"_blank",className:"px-3 py-2 rounded-lg bg-slate-200"}, t("toolbar.actions.files","Arquivos"))
         )
       )
     )
@@ -588,19 +665,19 @@ function InspectorPanel({row,onClose,onMark,onReset}){
     return null;
   }
   const info = [
-    {label: "Status atual", value: row.status || row["match.status"]},
-    {label: "Estrategia", value: row["match.strategy"]},
-    {label: "Score", value: row["match.score"]},
-    {label: "Sucessor", value: row["S.doc"]},
-    {label: "Fonte", value: row["F.doc"]},
-    {label: "Delta Valor", value: row["delta.valor"]},
-    {label: "Delta Dias", value: row["delta.dias"]},
-    {label: "Motivos", value: row.motivos}
+    {label: t("inspector.fields.currentStatus","Status atual"), value: row.status || row["match.status"]},
+    {label: t("inspector.fields.strategy","Estrategia"), value: row["match.strategy"]},
+    {label: t("inspector.fields.score","Score"), value: row["match.score"]},
+    {label: t("inspector.fields.sucessor","Sucessor"), value: row["S.doc"]},
+    {label: t("inspector.fields.source","Fonte"), value: row["F.doc"]},
+    {label: t("inspector.fields.deltaValue","Delta Valor"), value: row["delta.valor"]},
+    {label: t("inspector.fields.deltaDays","Delta Dias"), value: row["delta.dias"]},
+    {label: t("inspector.fields.reasons","Motivos"), value: row.motivos}
   ];
   return React.createElement("div",{className:"mt-6 bg-white shadow-soft rounded-xl border border-slate-200"},
     React.createElement("div",{className:"flex items-start justify-between px-4 py-3 border-b border-slate-200"},
-      React.createElement("h3",{className:"text-lg font-semibold"},"Detalhes da selecao"),
-      React.createElement("button",{className:"text-sm text-slate-500 hover:text-slate-700",onClick:onClose},"Fechar")
+      React.createElement("h3",{className:"text-lg font-semibold"},t("inspector.title","Detalhes da selecao")),
+      React.createElement("button",{className:"text-sm text-slate-500 hover:text-slate-700",onClick:onClose},t("common.close","Fechar"))
     ),
     React.createElement("div",{className:"px-4 py-4 grid gap-3 md:grid-cols-2"},
       info.map((item,idx)=>React.createElement("div",{key:idx},
@@ -609,9 +686,9 @@ function InspectorPanel({row,onClose,onMark,onReset}){
       ))
     ),
     React.createElement("div",{className:"px-4 pb-4 flex flex-wrap gap-2"},
-      React.createElement("button",{className:"px-3 py-1 rounded bg-emerald-100 text-emerald-800 text-sm",onClick:()=>onMark(row,"OK")},"Marcar OK"),
-      React.createElement("button",{className:"px-3 py-1 rounded bg-rose-100 text-rose-800 text-sm",onClick:()=>onMark(row,"DIVERGENCIA")},"Marcar Divergencia"),
-      React.createElement("button",{className:"px-3 py-1 rounded bg-slate-200 text-slate-700 text-sm",onClick:()=>onReset(row)},"Reverter")
+      React.createElement("button",{className:"px-3 py-1 rounded bg-emerald-100 text-emerald-800 text-sm",onClick:()=>onMark(row,"OK")},t("inspector.actions.markOk","Marcar OK")),
+      React.createElement("button",{className:"px-3 py-1 rounded bg-rose-100 text-rose-800 text-sm",onClick:()=>onMark(row,"DIVERGENCIA")},t("inspector.actions.markDivergence","Marcar Divergencia")),
+      React.createElement("button",{className:"px-3 py-1 rounded bg-slate-200 text-slate-700 text-sm",onClick:()=>onReset(row)},t("inspector.actions.reset","Reverter"))
     )
   );
 }
@@ -635,19 +712,36 @@ function Table({columns,items,resolveRowId,selectedRowId,sortBy,setSortBy,sortDi
     }
   },[onSortChange, setSortBy, setSortDir, sortBy, sortDir]);
   const tableItems = Array.isArray(items) ? items : [];
+  const getColumnLabel = useCallback((column)=>{
+    if(!column){
+      return "";
+    }
+    const fallback = column.label || column.labelFallback || column.id;
+    if(column.labelKey){
+      return t(column.labelKey, fallback);
+    }
+    return fallback;
+  },[]);
+  const statusHeader = t("table.headers.status","Status");
+  const actionsHeader = t("table.headers.actions","Acoes");
+  const markOkLabel = t("table.actions.markOk","Marcar OK");
+  const markDivergenceLabel = t("table.actions.markDivergence","Marcar Divergencia");
+  const resetLabel = t("table.actions.reset","Reverter");
+  const loadingTitle = t("table.loading.title","Carregando dados...");
+  const loadingDescription = t("table.loading.description","Estamos preparando a grade para exibição.");
   const hasItems = tableItems.length > 0;
   const showEmptyState = !loading && !hasItems;
-  const emptyLabel = emptyMessage || "Nenhum registro encontrado.";
-  const emptyDetails = emptyHint || "Ajuste os filtros ou processe novos dados.";
+  const emptyLabel = emptyMessage || t("table.empty.title","Nenhum registro encontrado.");
+  const emptyDetails = emptyHint || t("table.empty.description","Ajuste os filtros ou processe novos dados.");
   return (
     React.createElement("div",{className:"relative min-h-[240px]", "aria-busy": loading ? "true" : "false"},
       React.createElement("div",{className:"overflow-auto rounded-xl shadow-soft border bg-white h-full"},
         React.createElement("table",{className:"min-w-[1200px] w-full table-sticky"},
           React.createElement("thead",null,
             React.createElement("tr",null,
-              React.createElement("th",{className:"text-left px-3 py-2 w-28"},"Status"),
-              React.createElement("th",{className:"text-left px-3 py-2 w-44"},"Acoes"),
-              columns.map(col=>React.createElement("th",{key:col.id,className:"text-left px-3 py-2 cursor-pointer",onClick:()=>setSort(col.id)}, col.label||col.id))
+              React.createElement("th",{className:"text-left px-3 py-2 w-28"},statusHeader),
+              React.createElement("th",{className:"text-left px-3 py-2 w-44"},actionsHeader),
+              columns.map(col=>React.createElement("th",{key:col.id,className:"text-left px-3 py-2 cursor-pointer",onClick:()=>setSort(col.id)}, getColumnLabel(col)))
             )
           ),
           React.createElement("tbody",null,
@@ -661,9 +755,9 @@ function Table({columns,items,resolveRowId,selectedRowId,sortBy,setSortBy,sortDi
               React.createElement("td",{className:"px-3 py-2 align-top"}, React.createElement(Badge,{status:s})),
               React.createElement("td",{className:"px-3 py-2 align-top"},
                 React.createElement("div",{className:"flex flex-col gap-1"},
-                  React.createElement("button",{className:"px-2 py-1 rounded bg-emerald-100 text-emerald-800 text-xs",onClick:(e)=>{e.stopPropagation(); onManualStatus && onManualStatus(r,"OK")}},"Marcar OK"),
-                  React.createElement("button",{className:"px-2 py-1 rounded bg-rose-100 text-rose-800 text-xs",onClick:(e)=>{e.stopPropagation(); onManualStatus && onManualStatus(r,"DIVERGENCIA")}},"Marcar Divergencia"),
-                  React.createElement("button",{className:"px-2 py-1 rounded bg-slate-200 text-slate-700 text-xs",disabled:!r._manual,onClick:(e)=>{e.stopPropagation(); onResetStatus && onResetStatus(r)}},"Reverter")
+                  React.createElement("button",{className:"px-2 py-1 rounded bg-emerald-100 text-emerald-800 text-xs",onClick:(e)=>{e.stopPropagation(); onManualStatus && onManualStatus(r,"OK")}},markOkLabel),
+                  React.createElement("button",{className:"px-2 py-1 rounded bg-rose-100 text-rose-800 text-xs",onClick:(e)=>{e.stopPropagation(); onManualStatus && onManualStatus(r,"DIVERGENCIA")}},markDivergenceLabel),
+                  React.createElement("button",{className:"px-2 py-1 rounded bg-slate-200 text-slate-700 text-xs",disabled:!r._manual,onClick:(e)=>{e.stopPropagation(); onResetStatus && onResetStatus(r)}},resetLabel)
                 )
               ),
               columns.map(col=>{
@@ -682,8 +776,8 @@ function Table({columns,items,resolveRowId,selectedRowId,sortBy,setSortBy,sortDi
       ),
       loading ? React.createElement("div",{className:"absolute inset-0 flex flex-col items-center justify-center gap-2 bg-white/80 backdrop-blur-sm text-indigo-700",role:"status","aria-live":"polite"},
         React.createElement("span",{className:"spinner","aria-hidden":"true"}),
-        React.createElement("p",{className:"text-sm font-semibold"},"Carregando dados..."),
-        React.createElement("p",{className:"text-xs"},"Estamos preparando a grade para exibição.")
+        React.createElement("p",{className:"text-sm font-semibold"},loadingTitle),
+        React.createElement("p",{className:"text-xs"},loadingDescription)
       ) : null,
       showEmptyState ? React.createElement("div",{className:"pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 bg-white/70 text-slate-600"},
         React.createElement("p",{className:"text-sm font-semibold"}, emptyLabel),
@@ -698,13 +792,21 @@ function Paginator({offset,setOffset,limit,setLimit,total,go}){
   const canNext = offset+limit < total;
   const page = Math.floor(offset/limit)+1;
   const pages = Math.max(1, Math.ceil(total/limit));
+  const summaryText = t("paginator.summary","Mostrando {start}-{end} de {total}",{
+    start: Math.min(total, offset+1),
+    end: Math.min(total, offset+limit),
+    total
+  });
+  const pageText = t("paginator.page","Pagina {page}/{pages}",{page,pages});
+  const previousLabel = t("paginator.previous","Anterior");
+  const nextLabel = t("paginator.next","Próximo");
   return (
     React.createElement("div",{className:"flex items-center justify-between mt-3"},
-      React.createElement("div",null, `Mostrando ${Math.min(total, offset+1)}-${Math.min(total, offset+limit)} de ${total}`),
+      React.createElement("div",null, summaryText),
       React.createElement("div",{className:"flex items-center gap-2"},
-        React.createElement("button",{disabled:!canPrev,onClick:()=>{ if(!canPrev) return; const nextOffset = Math.max(0, offset-limit); if(typeof go === "function"){ go(nextOffset); } },className:"px-3 py-1 rounded bg-slate-200 disabled:opacity-50"},"<"),
-        React.createElement("span",null, `Pagina ${page}/${pages}`),
-        React.createElement("button",{disabled:!canNext,onClick:()=>{ if(!canNext) return; const nextOffset = offset+limit; if(typeof go === "function"){ go(nextOffset); } },className:"px-3 py-1 rounded bg-slate-200 disabled:opacity-50"},">"),
+        React.createElement("button",{disabled:!canPrev,onClick:()=>{ if(!canPrev) return; const nextOffset = Math.max(0, offset-limit); if(typeof go === "function"){ go(nextOffset); } },className:"px-3 py-1 rounded bg-slate-200 disabled:opacity-50", "aria-label": previousLabel},"<"),
+        React.createElement("span",null, pageText),
+        React.createElement("button",{disabled:!canNext,onClick:()=>{ if(!canNext) return; const nextOffset = offset+limit; if(typeof go === "function"){ go(nextOffset); } },className:"px-3 py-1 rounded bg-slate-200 disabled:opacity-50", "aria-label": nextLabel},">"),
         React.createElement("select",{className:"px-2 py-1 rounded bg-white border",value:limit,onChange:e=>{const nextLimit = parseInt(e.target.value,10); setOffset(0); setLimit(nextLimit);}},
           [50,100,200,500,1000].map(n=>React.createElement("option",{key:n,value:n}, n))
         )
@@ -736,21 +838,54 @@ function computeToolbarStats(meta){
 function App(){
   const api = useApi(); // ajuste `window.UI_API_BASE` ou use ?api= para apontar para outro host/porta
   const {addToast} = useToast();
+  const defaultErrorTitle = t("toast.defaults.errorTitle","Erro");
+  const defaultErrorDescription = t("toast.defaults.errorDescription","Ocorreu um erro inesperado.");
+  const defaultWarningTitle = t("toast.defaults.warningTitle","Aviso");
+  const defaultWarningDescription = t("toast.defaults.warningDescription","Verifique as informações exibidas.");
+  const metaErrorTitle = t("app.notifications.metaError","Erro ao carregar metadados");
+  const gridErrorTitle = t("app.notifications.gridError","Erro ao carregar dados");
+  const gridErrorMessage = t("app.notifications.gridErrorMessage","Não foi possível carregar os dados da grade. Tente novamente.");
+  const confirmClearMessage = t("app.confirm.clearData","Tem certeza que deseja limpar os dados processados? Esta ação não pode ser desfeita.");
+  const clearSuccessTitle = t("app.notifications.clearSuccessTitle","Dados limpos");
+  const clearSuccessMessage = t("app.notifications.clearSuccessMessage","Os dados processados foram removidos.");
+  const clearErrorToastTitle = t("app.notifications.clearErrorToastTitle","Erro ao limpar dados");
+  const clearErrorFallback = t("app.notifications.clearErrorFallback","Não foi possível limpar os dados processados.");
+  const processingFailedTitle = t("app.notifications.processingFailedTitle","Processamento falhou");
+  const processingFailedMessage = t("app.notifications.processingFailedMessage","O processamento foi interrompido.");
+  const processingCancelledTitle = t("app.notifications.processingCancelledTitle","Processamento cancelado");
+  const processingCancelledMessage = t("app.notifications.processingCancelledMessage","O processamento foi interrompido antes da conclusão.");
+  const cancelProcessErrorTitle = t("app.notifications.cancelProcessError","Não foi possível cancelar o processamento");
+  const exportJsonErrorTitle = t("app.notifications.exportJsonError","Erro ao exportar JSON");
+  const exportXlsxErrorTitle = t("app.notifications.exportXlsxError","Erro ao exportar XLSX");
+  const exportPdfErrorTitle = t("app.notifications.exportPdfError","Erro ao exportar PDF");
+  const processStartErrorTitle = t("app.notifications.processStartError","Erro ao iniciar processamento");
+  const uploadErrorTitle = t("app.notifications.uploadError","Erro no envio de arquivos");
+  const manualSaveErrorTitle = t("app.notifications.manualSaveError","Falha ao salvar ajuste manual");
+  const manualRemoveErrorTitle = t("app.notifications.manualRemoveError","Falha ao remover ajuste manual");
+  const emptyFilteredMessage = t("app.empty.filtered","Nenhum registro encontrado para os filtros selecionados.");
+  const emptyDefaultMessage = t("app.empty.default","Nenhum dado disponível no momento.");
+  const emptyFilteredHint = t("app.empty.filteredHint","Ajuste os filtros ou limpe os campos para visualizar outros resultados.");
+  const emptyDefaultHint = t("app.empty.defaultHint","Envie novos arquivos para gerar a grade de conferência.");
+  const appTitle = t("app.header.title","App de Conferencia - UI");
+  const subtitleTemplate = t("app.header.subtitle","Carrega {file} do servidor local e exibe a grade com filtros e exports.");
+  const subtitleFile = t("app.header.subtitleFile","ui_grid.jsonl");
+  const processButtonProcessing = t("app.actions.processing","Processando...");
+  const processButtonLabel = t("app.actions.process","Processar");
   const showErrorToast = useCallback((title, error)=>{
     const description = error && error.message ? error.message : (typeof error === "string" ? error : null);
     addToast({
       type:"error",
-      title: title || "Erro",
-      description: description || "Ocorreu um erro inesperado."
+      title: title || defaultErrorTitle,
+      description: description || defaultErrorDescription
     });
-  },[addToast]);
+  },[addToast, defaultErrorDescription, defaultErrorTitle]);
   const showWarningToast = useCallback((title, description)=>{
     addToast({
       type:"warning",
-      title: title || "Aviso",
-      description: description || "Verifique as informações exibidas."
+      title: title || defaultWarningTitle,
+      description: description || defaultWarningDescription
     });
-  },[addToast]);
+  },[addToast, defaultWarningDescription, defaultWarningTitle]);
   const [schema,setSchema] = useState(null);
   const [meta,setMeta] = useState(null);
   const [items,setItems] = useState([]);
@@ -809,9 +944,9 @@ function App(){
       setMeta(m);
     }catch(e){
       console.error("Falha ao carregar metadados", e);
-      showErrorToast("Erro ao carregar metadados", e);
+      showErrorToast(metaErrorTitle, e);
     }
-  },[api, showErrorToast]);
+  },[api, metaErrorTitle, showErrorToast]);
 
   const loadGrid = useCallback(async (nextOffset, nextFilters)=>{
     const hasOverride = typeof nextOffset === "number" && !Number.isNaN(nextOffset);
@@ -838,13 +973,13 @@ function App(){
       setTotal(res.total_filtered || 0);
     }catch(e){
       console.error("Falha ao carregar grade", e);
-      setError("Não foi possível carregar os dados da grade. Tente novamente.");
+      setError(gridErrorMessage);
       setItems([]);
       setTotal(0);
-      showErrorToast("Erro ao carregar dados", e);
+      showErrorToast(gridErrorTitle, e);
     }
     finally{ setLoading(false); }
-  },[api, filters, sortBy, sortDir, limit, offset, skipNextAutoLoad, showErrorToast]);
+  },[api, filters, sortBy, sortDir, limit, offset, skipNextAutoLoad, gridErrorMessage, gridErrorTitle, showErrorToast]);
 
   useEffect(()=>{ loadMeta(); },[loadMeta]);
   useEffect(()=>{
@@ -898,7 +1033,7 @@ function App(){
     if(clearingData){
       return;
     }
-    const confirmed = window.confirm("Tem certeza que deseja limpar os dados processados? Esta ação não pode ser desfeita.");
+    const confirmed = window.confirm(confirmClearMessage);
     if(!confirmed){
       return;
     }
@@ -912,21 +1047,21 @@ function App(){
       setSelectedRow(null);
       addToast({
         type:"success",
-        title:"Dados limpos",
-        description:"Os dados processados foram removidos."
+        title:clearSuccessTitle,
+        description:clearSuccessMessage
       });
     }catch(err){
       console.error("Falha ao limpar dados", err);
       const message = err && err.message ? err.message : String(err);
       addToast({
         type:"error",
-        title:"Erro ao limpar dados",
-        description: message
+        title:clearErrorToastTitle,
+        description: message || clearErrorFallback
       });
     }finally{
       setClearingData(false);
     }
-  },[addToast, api, clearingData]);
+  },[addToast, api, clearingData, clearErrorFallback, clearErrorToastTitle, clearSuccessMessage, clearSuccessTitle, confirmClearMessage]);
 
   const exportJ = async ()=>{
     try{
@@ -936,7 +1071,7 @@ function App(){
       if(link){ window.open(link,"_blank"); }
     }catch(e){
       console.error("Falha no export JSON", e);
-      showErrorToast("Erro ao exportar JSON", e);
+      showErrorToast(exportJsonErrorTitle, e);
     }
   };
   const exportX = async ()=>{
@@ -946,7 +1081,7 @@ function App(){
       if(res.download){ window.open(res.download,"_blank"); }
     }catch(e){
       console.error("Falha no export XLSX", e);
-      showErrorToast("Erro ao exportar XLSX", e);
+      showErrorToast(exportXlsxErrorTitle, e);
     }
   };
   const exportP = async ()=>{
@@ -957,7 +1092,7 @@ function App(){
       if(link){ window.open(link,"_blank"); }
     }catch(e){
       console.error("Falha no export PDF", e);
-      showErrorToast("Erro ao exportar PDF", e);
+      showErrorToast(exportPdfErrorTitle, e);
     }
   };
 
@@ -977,11 +1112,11 @@ function App(){
     }catch(err){
       console.error("Falha ao solicitar cancelamento do job", err);
       const message = err && err.message ? err.message : String(err);
-      showErrorToast("Não foi possível cancelar o processamento", message);
+      showErrorToast(cancelProcessErrorTitle, message);
     }finally{
       setJobCanceling(false);
     }
-  },[api,currentJobId,jobCanceling,showErrorToast]);
+  },[api,cancelProcessErrorTitle,currentJobId,jobCanceling,showErrorToast]);
 
   const openUploadModal = ()=>{
     setUploadError(null);
@@ -1008,7 +1143,7 @@ function App(){
           const message = processErr && processErr.message ? processErr.message : String(processErr);
           setUploadError(message);
           console.error("Falha ao iniciar processamento", processErr);
-          showErrorToast("Erro ao iniciar processamento", message);
+          showErrorToast(processStartErrorTitle, message);
           return;
         }
         setCurrentJobId(jobId);
@@ -1029,7 +1164,7 @@ function App(){
       const message = err && err.message ? err.message : String(err);
       setUploadError(message);
       console.error("Falha no envio de arquivos", err);
-      showErrorToast("Erro no envio de arquivos", message);
+      showErrorToast(uploadErrorTitle, message);
     }finally{
       setUploading(false);
     }
@@ -1067,7 +1202,7 @@ function App(){
       });
     }catch(e){
       console.error("Falha ao salvar override manual", e);
-      showErrorToast("Falha ao salvar ajuste manual", e);
+      showErrorToast(manualSaveErrorTitle, e);
       return;
     }
     let updatedRow = null;
@@ -1102,7 +1237,7 @@ function App(){
       await api.del("/api/manual-status",{params:{row_id: rowKey}});
     }catch(e){
       console.error("Falha ao remover override manual", e);
-      showErrorToast("Falha ao remover ajuste manual", e);
+      showErrorToast(manualRemoveErrorTitle, e);
       return;
     }
     let updatedRow = null;
@@ -1158,7 +1293,7 @@ function App(){
           if(!cancelled){
             const lastLog = Array.isArray(res?.logs) && res.logs.length ? res.logs[res.logs.length-1] : null;
             const message = res?.message || lastLog?.message || lastLog?.label;
-            showErrorToast("Processamento falhou", message || "O processamento foi interrompido.");
+            showErrorToast(processingFailedTitle, message || processingFailedMessage);
           }
         }else if(normalized === "cancelled"){
           if(timerId){ clearInterval(timerId); timerId = null; }
@@ -1166,7 +1301,7 @@ function App(){
           setJobStatus(null);
           setJobCanceling(false);
           if(!cancelled){
-            showWarningToast("Processamento cancelado", "O processamento foi interrompido antes da conclusão.");
+            showWarningToast(processingCancelledTitle, processingCancelledMessage);
           }
         }
       }catch(pollErr){
@@ -1179,30 +1314,43 @@ function App(){
       cancelled = true;
       if(timerId){ clearInterval(timerId); }
     };
-  },[api, currentJobId, loadGrid, loadMeta, showErrorToast, showWarningToast]);
+  },[api, currentJobId, loadGrid, loadMeta, processingCancelledMessage, processingCancelledTitle, processingFailedMessage, processingFailedTitle, showErrorToast, showWarningToast]);
 
   const toolbarStats = useMemo(()=> computeToolbarStats(meta),[meta]);
   const hasActiveFilters = useMemo(()=>{
     const current = filters || {};
     return Object.values(current).some(value=> Boolean(value));
   },[filters]);
-  const emptyStateMessage = hasActiveFilters ? "Nenhum registro encontrado para os filtros selecionados." : "Nenhum dado disponível no momento.";
-  const emptyStateHint = hasActiveFilters ? "Ajuste os filtros ou limpe os campos para visualizar outros resultados." : "Envie novos arquivos para gerar a grade de conferência.";
-  
+  const emptyStateMessage = hasActiveFilters ? emptyFilteredMessage : emptyDefaultMessage;
+  const emptyStateHint = hasActiveFilters ? emptyFilteredHint : emptyDefaultHint;
+  const subtitleChildren = useMemo(()=>{
+    const parts = subtitleTemplate.split("{file}");
+    const nodes = [];
+    parts.forEach((part,index)=>{
+      if(part){
+        nodes.push(part);
+      }
+      if(index < parts.length - 1){
+        nodes.push(React.createElement("code",{key:`subtitle-file-${index}`}, subtitleFile));
+      }
+    });
+    return nodes;
+  },[subtitleFile, subtitleTemplate]);
+
   return (
 
     React.createElement("div",{className:"max-w-[1400px] mx-auto p-4 md:p-6"},
       React.createElement("div",{className:"mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between"},
         React.createElement("div",{className:"space-y-1"},
-          React.createElement("h2",{className:"text-2xl font-semibold"},"App de Conferencia - UI"),
-          React.createElement("p",{className:"text-slate-600"},"Carrega ", React.createElement("code",null,"ui_grid.jsonl"), " do servidor local e exibe a grade com filtros e exports.")
+          React.createElement("h2",{className:"text-2xl font-semibold"},appTitle),
+          React.createElement("p",{className:"text-slate-600"},...subtitleChildren)
         ),
         React.createElement("div",{className:"flex gap-2"},
           React.createElement("button",{
             onClick:openUploadModal,
             disabled:uploading || jobRunning,
             className:"rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-soft hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-          }, (uploading || jobRunning)?"Processando...":"Processar")
+          }, (uploading || jobRunning)?processButtonProcessing:processButtonLabel)
         )
       ),
       currentJobId && jobStatus ? React.createElement(JobProgressPanel,{
@@ -1263,8 +1411,14 @@ function App(){
   );
 }
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(React.createElement(ToastProvider,null,React.createElement(App)));
+function startApp(){
+  const root = ReactDOM.createRoot(document.getElementById("root"));
+  root.render(React.createElement(ToastProvider,null,React.createElement(App)));
+}
+
+loadTranslations(I18N_DEFAULT_LOCALE).finally(()=>{
+  startApp();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a lightweight translation loader and delay bootstrapping until locale resources are available
- replace hard-coded interface messages with translation lookups across the upload flow, toolbar, tables, and job progress UI
- provide a pt-BR JSON catalog containing all current UI strings for easier future localization

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dabcf130fc832fb8a0e8b0d1cbdf53